### PR TITLE
Add initial build scripts and files for Windows 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,8 @@ if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
 	message(FATAL_ERROR "64-bit builds not supported: check compiler or Windows shell environment.")
 endif()
 
-# For debug only
-add_compile_definitions(TBB_USE_THREADING_TOOLS=0)
-add_compile_definitions(TBB_USE_ASSERT=0)
-
 # Disable ptex support for now
 set(PXR_ENABLE_PTEX_SUPPORT FALSE)
-
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
                       ${CMAKE_SOURCE_DIR}/cmake/defaults
@@ -40,7 +35,6 @@ set(CMAKE_CXX_FLAGS "${_PXR_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 include(Public)
 
-# Visual Studio
 set(CMAKE_CXX_STANDARD 14)
 
 # For some reason Python detection doesn't use a directory
@@ -55,10 +49,12 @@ link_directories(${USD_ROOT}/lib)
 # Add LuxCore libraries from the environment
 set(LUXCORE_ROOT $ENV{LUXCORE_ROOT})
 add_library(LuxCore SHARED IMPORTED)
-set_target_properties(LuxCore PROPERTIES
-    IMPORTED_LOCATION "${LUXCORE_ROOT}/lib/luxcore.dll"
-    IMPORTED_IMPLIB "${LUXCORE_ROOT}/lib/luxcore.lib"
-    INTERFACE_INCLUDE_DIRECTORIES "${LUXCORE_ROOT}/include"
-)
+if (WIN32)
+    set_target_properties(LuxCore PROPERTIES
+        IMPORTED_LOCATION "${LUXCORE_ROOT}/lib/luxcore.dll"
+        IMPORTED_IMPLIB "${LUXCORE_ROOT}/lib/luxcore.lib"
+        INTERFACE_INCLUDE_DIRECTORIES "${LUXCORE_ROOT}/include"
+    )
+endif()
 
 add_subdirectory(pxr/imaging/plugin/hdLuxCore)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,64 @@
+project(luxcorerenderusd)
+
+cmake_minimum_required(VERSION 3.16.0)
+
+if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+	message(FATAL_ERROR "64-bit builds not supported: check compiler or Windows shell environment.")
+endif()
+
+# For debug only
+add_compile_definitions(TBB_USE_THREADING_TOOLS=0)
+add_compile_definitions(TBB_USE_ASSERT=0)
+
+# Disable ptex support for now
+set(PXR_ENABLE_PTEX_SUPPORT FALSE)
+
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
+                      ${CMAKE_SOURCE_DIR}/cmake/defaults
+                      ${CMAKE_SOURCE_DIR}/cmake/modules
+                      ${CMAKE_SOURCE_DIR}/cmake/macros)
+
+include(Options)
+include(ProjectDefaults)
+include(Packages)
+
+# This has to be defined after Packages is included, because it relies on the
+# discovered path to the python executable.
+set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}" 
+    CACHE 
+    STRING
+    "Replacement path for Python #! line."
+)
+
+# CXXDefaults will set a variety of variables for the project.
+# Consume them here. This is an effort to keep the most common
+# build files readable.
+include(CXXDefaults)
+add_definitions(${_PXR_CXX_DEFINITIONS})
+set(CMAKE_CXX_FLAGS "${_PXR_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+
+include(Public)
+
+# Visual Studio
+set(CMAKE_CXX_STANDARD 14)
+
+# For some reason Python detection doesn't use a directory
+get_filename_component(PYTHON_LIBRARY_DIR ${PYTHON_LIBRARY} DIRECTORY)
+link_directories(${PYTHON_LIBRARY_DIR})
+
+# Add USD Libraries from the environment
+set(USD_ROOT $ENV{USD_ROOT})
+include_directories(${USD_ROOT}/include)
+link_directories(${USD_ROOT}/lib)
+
+# Add LuxCore libraries from the environment
+set(LUXCORE_ROOT $ENV{LUXCORE_ROOT})
+add_library(LuxCore SHARED IMPORTED)
+set_target_properties(LuxCore PROPERTIES
+    IMPORTED_LOCATION "${LUXCORE_ROOT}/lib/luxcore.dll"
+    IMPORTED_IMPLIB "${LUXCORE_ROOT}/lib/luxcore.lib"
+    INTERFACE_INCLUDE_DIRECTORIES "${LUXCORE_ROOT}/include"
+)
+
+add_subdirectory(pxr/imaging/plugin/hdLuxCore)

--- a/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
@@ -1,0 +1,60 @@
+set(PXR_PREFIX pxr/imaging)
+set(PXR_PACKAGE hdLuxCore)
+add_custom_target(shared_libs)
+
+set(optionalPublicClasses "")
+
+if (OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK)
+    add_definitions(-DOPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK)
+endif()
+if (OPENSUBDIV_HAS_GLSL_COMPUTE)
+    add_definitions(-DOPENSUBDIV_HAS_GLSL_COMPUTE)
+endif()
+
+pxr_plugin(hdLuxCore
+    LIBRARIES
+        ar
+        arch
+        sdf
+        trace
+        plug
+        tf
+        vt
+        gf
+        glf
+        work
+        hf
+        hd
+        hdSt
+        hdx
+        usdLux
+        usdUtils
+        pxOsd
+        ${Boost_LIBRARIES} 
+        ${RIF_LIBRARY}
+        ${OPENSUBDIV_LIBRARIES}
+        ${TBB_tbb_LIBRARY}
+        LuxCore
+
+    INCLUDE_DIRS
+        ${RIF_LOCATION_INCLUDE}
+        ${GLEW_INCLUDE_DIR}
+        ${OPENSUBDIV_INCLUDE_DIR}
+        ${Boost_INCLUDE_DIR} 
+        ${TBB_INCLUDE_DIRS}
+
+    PUBLIC_CLASSES
+        rendererPlugin
+        renderDelegate
+        instancer
+        sampler
+        renderPass
+        renderer
+        renderBuffer
+
+    PUBLIC_HEADERS
+        renderParam.h
+
+    RESOURCE_FILES
+        plugInfo.json
+)

--- a/pxr/imaging/plugin/hdLuxCore/pch.h
+++ b/pxr/imaging/plugin/hdLuxCore/pch.h
@@ -160,9 +160,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/value_init.hpp>
 #include <boost/weak_ptr.hpp>
-#include <embree2/rtcore.h>
-#include <embree2/rtcore_geometry.h>
-#include <embree2/rtcore_ray.h>
 #include <tbb/atomic.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_vector.h>

--- a/pxr/imaging/plugin/hdLuxCore/plugInfo.json
+++ b/pxr/imaging/plugin/hdLuxCore/plugInfo.json
@@ -12,10 +12,10 @@
                     }
                 }
             },
-            "LibraryPath": "@PLUG_INFO_LIBRARY_PATH@",
+            "LibraryPath": "../hdLuxCore.dll",
             "Name": "hdLuxCore",
-            "ResourcePath": "@PLUG_INFO_RESOURCE_PATH@",
-            "Root": "@PLUG_INFO_ROOT@",
+            "ResourcePath": "resources",
+            "Root": "..",
             "Type": "library"
         }
     ]

--- a/pxr/imaging/plugin/hdLuxCore/renderBuffer.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderBuffer.cpp
@@ -1,0 +1,329 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/imaging/hdLuxCore/renderParam.h"
+#include "pxr/imaging/hdLuxCore/renderBuffer.h"
+#include "pxr/base/gf/half.h"
+
+#include <iostream>
+using namespace std;
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdLuxCoreRenderBuffer::HdLuxCoreRenderBuffer(SdfPath const& id)
+    : HdRenderBuffer(id)
+    , _width(0)
+    , _height(0)
+    , _format(HdFormatInvalid)
+    , _multiSampled(false)
+    , _buffer()
+    , _sampleBuffer()
+    , _sampleCount()
+    , _mappers(0)
+    , _converged(false)
+{
+    cout << "HdLuxCoreRenderBuffer::HdLuxCoreRenderBuffer()\n";
+}
+
+HdLuxCoreRenderBuffer::~HdLuxCoreRenderBuffer()
+{
+    cout << "HdLuxCoreRenderBuffer::~HdLuxCoreRenderBuffer()\n";
+}
+
+/*virtual*/
+void
+HdLuxCoreRenderBuffer::Sync(HdSceneDelegate *sceneDelegate,
+                           HdRenderParam *renderParam,
+                           HdDirtyBits *dirtyBits)
+{
+    cout << "HdLuxCoreRenderBuffer::Sync() start\n";
+    if (*dirtyBits & DirtyDescription) {
+        cout << "HdLuxCoreRenderBuffer::Sync() inside dirtybits & dirtydescription block start\n";
+        // LuxCore has the background thread write directly into render buffers,
+        // so we need to stop the render thread before reallocating them.
+        static_cast<HdLuxCoreRenderParam*>(renderParam)->AcquireSceneForEdit();
+    }
+
+    cout << "HdLuxCoreRenderBuffer::Before HdRenderBuffer::Sync()\n";
+    HdRenderBuffer::Sync(sceneDelegate, renderParam, dirtyBits);
+    cout << "HdLuxCoreRenderBuffer::Sync() end\n";
+}
+
+/*virtual*/
+void
+HdLuxCoreRenderBuffer::Finalize(HdRenderParam *renderParam)
+{
+    cout << "HdLuxCoreRenderBuffer::Finalize()\n";
+    // LuxCore has the background thread write directly into render buffers,
+    // so we need to stop the render thread before removing them.
+    static_cast<HdLuxCoreRenderParam*>(renderParam)->AcquireSceneForEdit();
+
+    HdRenderBuffer::Finalize(renderParam);
+}
+
+/*virtual*/
+void
+HdLuxCoreRenderBuffer::_Deallocate()
+{
+    cout << "HdLuxCoreRenderBuffer::_Deallocate()\n";
+    // If the buffer is mapped while we're doing this, there's not a great
+    // recovery path...
+    TF_VERIFY(!IsMapped());
+
+    _width = 0;
+    _height = 0;
+    _format = HdFormatInvalid;
+    _multiSampled = false;
+    _buffer.resize(0);
+    _sampleBuffer.resize(0);
+    _sampleCount.resize(0);
+
+    _mappers.store(0);
+    _converged.store(false);
+}
+
+/*static*/
+size_t
+HdLuxCoreRenderBuffer::_GetBufferSize(GfVec2i const &dims, HdFormat format)
+{
+    cout << "HdLuxCoreRenderBuffer::_GetBufferSize()\n";
+    return dims[0] * dims[1] * HdDataSizeOfFormat(format);
+}
+
+/*static*/
+HdFormat
+HdLuxCoreRenderBuffer::_GetSampleFormat(HdFormat format)
+{
+    cout << "HdLuxCoreRenderBuffer::_GetSampleFormat()\n";
+    HdFormat component = HdGetComponentFormat(format);
+    size_t arity = HdGetComponentCount(format);
+
+    if (component == HdFormatUNorm8 || component == HdFormatSNorm8 ||
+        component == HdFormatFloat16 || component == HdFormatFloat32) {
+        if (arity == 1) { return HdFormatFloat32; }
+        else if (arity == 2) { return HdFormatFloat32Vec2; }
+        else if (arity == 3) { return HdFormatFloat32Vec3; }
+        else if (arity == 4) { return HdFormatFloat32Vec4; }
+    } else if (component == HdFormatInt32) {
+        if (arity == 1) { return HdFormatInt32; }
+        else if (arity == 2) { return HdFormatInt32Vec2; }
+        else if (arity == 3) { return HdFormatInt32Vec3; }
+        else if (arity == 4) { return HdFormatInt32Vec4; }
+    }
+    return HdFormatInvalid;
+}
+
+/*virtual*/
+bool
+HdLuxCoreRenderBuffer::Allocate(GfVec3i const& dimensions,
+                               HdFormat format,
+                               bool multiSampled)
+{
+    cout << "HdLuxCoreRenderBuffer::Allocate()\n";
+    _Deallocate();
+
+    if (dimensions[2] != 1) {
+        TF_WARN("Render buffer allocated with dims <%d, %d, %d> and"
+                " format %s; depth must be 1!",
+                dimensions[0], dimensions[1], dimensions[2],
+                TfEnum::GetName(format).c_str());
+        return false;
+    }
+
+    _width = dimensions[0];
+    _height = dimensions[1];
+    _format = format;
+    _buffer.resize(_GetBufferSize(GfVec2i(_width, _height), format));
+    
+    _multiSampled = multiSampled;
+    if (_multiSampled) {
+        _sampleBuffer.resize(_GetBufferSize(GfVec2i(_width, _height),
+            _GetSampleFormat(format)));
+        _sampleCount.resize(_width*_height);
+    }
+
+    return true;
+}
+
+template<typename T>
+static void _WriteSample(HdFormat format, uint8_t *dst,
+                         size_t valueComponents, T const* value)
+{
+    cout << "HdLuxCoreRenderBuffer::_WriteSample()\n";
+    HdFormat componentFormat = HdGetComponentFormat(format);
+    size_t componentCount = HdGetComponentCount(format);
+
+    for (size_t c = 0; c < componentCount; ++c) {
+        if (componentFormat == HdFormatInt32) {
+            ((int32_t*)dst)[c] +=
+                (c < valueComponents) ? (int32_t)(value[c]) : 0;
+        } else {
+            ((float*)dst)[c] +=
+                (c < valueComponents) ? (float)(value[c]) : 0.0f;
+        }
+    }
+}
+
+template<typename T>
+static void _WriteOutput(HdFormat format, uint8_t *dst,
+                         size_t valueComponents, T const* value)
+{
+    //cout << "HdLuxCoreRenderBuffer::_WriteOutput()\n";
+    HdFormat componentFormat = HdGetComponentFormat(format);
+    size_t componentCount = HdGetComponentCount(format);
+
+    for (size_t c = 0; c < componentCount; ++c) {
+        if (componentFormat == HdFormatInt32) {
+            ((int32_t*)dst)[c] =
+                (c < valueComponents) ? (int32_t)(value[c]) : 0;
+        } else if (componentFormat == HdFormatFloat16) {
+            ((uint16_t*)dst)[c] =
+                (c < valueComponents) ? GfHalf(value[c]).bits() : 0;
+        } else if (componentFormat == HdFormatFloat32) {
+            ((float*)dst)[c] =
+                (c < valueComponents) ? (float)(value[c]) : 0.0f;
+        } else if (componentFormat == HdFormatUNorm8) {
+            ((uint8_t*)dst)[c] =
+                (c < valueComponents) ? (uint8_t)(value[c] * 255.0f) : 0.0f;
+        } else if (componentFormat == HdFormatSNorm8) {
+            ((int8_t*)dst)[c] =
+                (c < valueComponents) ? (int8_t)(value[c] * 127.0f) : 0.0f;
+        }
+    }
+}
+
+void
+HdLuxCoreRenderBuffer::Write(
+    GfVec3i const& pixel, size_t numComponents, float const* value)
+{
+    cout << "HdLuxCoreRenderBuffer::Write()\n";
+    size_t idx = pixel[1]*_width+pixel[0];
+    if (_multiSampled) {
+        size_t formatSize = HdDataSizeOfFormat(_GetSampleFormat(_format));
+        uint8_t *dst = &_sampleBuffer[idx*formatSize];
+        _WriteSample(_format, dst, numComponents, value);
+        _sampleCount[idx]++;
+    } else {
+        size_t formatSize = HdDataSizeOfFormat(_format);
+        uint8_t *dst = &_buffer[idx*formatSize];
+        _WriteOutput(_format, dst, numComponents, value);
+    }
+}
+
+void
+HdLuxCoreRenderBuffer::Write(
+    GfVec3i const& pixel, size_t numComponents, int const* value)
+{
+    cout << "HdLuxCoreRenderBuffer::Write()\n";
+    size_t idx = pixel[1]*_width+pixel[0];
+    if (_multiSampled) {
+        size_t formatSize = HdDataSizeOfFormat(_GetSampleFormat(_format));
+        uint8_t *dst = &_sampleBuffer[idx*formatSize];
+        _WriteSample(_format, dst, numComponents, value);
+        _sampleCount[idx]++;
+    } else {
+        size_t formatSize = HdDataSizeOfFormat(_format);
+        uint8_t *dst = &_buffer[idx*formatSize];
+        _WriteOutput(_format, dst, numComponents, value);
+    }
+}
+
+void
+HdLuxCoreRenderBuffer::Clear(size_t numComponents, float const* value)
+{
+    cout << "HdLuxCoreRenderBuffer::Clear()\n";
+    size_t formatSize = HdDataSizeOfFormat(_format);
+    for (size_t i = 0; i < _width*_height; ++i) {
+        uint8_t *dst = &_buffer[i*formatSize];
+        _WriteOutput(_format, dst, numComponents, value);
+    }
+
+    if (_multiSampled) {
+        std::fill(_sampleCount.begin(), _sampleCount.end(), 0);
+        std::fill(_sampleBuffer.begin(), _sampleBuffer.end(), 0);
+    }
+}
+
+void
+HdLuxCoreRenderBuffer::Clear(size_t numComponents, int const* value)
+{
+    cout << "HdLuxCoreRenderBuffer::Clear()\n";
+    size_t formatSize = HdDataSizeOfFormat(_format);
+    for (size_t i = 0; i < _width*_height; ++i) {
+        uint8_t *dst = &_buffer[i*formatSize];
+        _WriteOutput(_format, dst, numComponents, value);
+    }
+
+    if (_multiSampled) {
+        std::fill(_sampleCount.begin(), _sampleCount.end(), 0);
+        std::fill(_sampleBuffer.begin(), _sampleBuffer.end(), 0);
+    }
+}
+
+/*virtual*/
+void
+HdLuxCoreRenderBuffer::Resolve()
+{
+    cout << "HdLuxCoreRenderBuffer::Resolve()\n";
+    // Resolve the image buffer: find the average value per pixel by
+    // dividing the summed value by the number of samples.
+
+    if (!_multiSampled) {
+        return;
+    }
+
+    HdFormat componentFormat = HdGetComponentFormat(_format);
+    size_t componentCount = HdGetComponentCount(_format);
+    size_t formatSize = HdDataSizeOfFormat(_format);
+    size_t sampleSize = HdDataSizeOfFormat(_GetSampleFormat(_format));
+
+    for (unsigned int i = 0; i < _width * _height; ++i) {
+
+        int sampleCount = _sampleCount[i];
+        // Skip pixels with no samples.
+        if (sampleCount == 0) {
+            continue;
+        }
+
+        uint8_t *dst = &_buffer[i*formatSize];
+        uint8_t *src = &_sampleBuffer[i*sampleSize];
+        for (size_t c = 0; c < componentCount; ++c) {
+            if (componentFormat == HdFormatInt32) {
+                ((int32_t*)dst)[c] = ((int32_t*)src)[c] / sampleCount;
+            } else if (componentFormat == HdFormatFloat16) {
+                ((uint16_t*)dst)[c] = GfHalf(
+                    ((float*)src)[c] / sampleCount).bits();
+            } else if (componentFormat == HdFormatFloat32) {
+                ((float*)dst)[c] = ((float*)src)[c] / sampleCount;
+            } else if (componentFormat == HdFormatUNorm8) {
+                ((uint8_t*)dst)[c] = (uint8_t)
+                    (((float*)src)[c] * 255.0f / sampleCount);
+            } else if (componentFormat == HdFormatSNorm8) {
+                ((int8_t*)dst)[c] = (int8_t)
+                    (((float*)src)[c] * 127.0f / sampleCount);
+            }
+        }
+    }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdLuxCore/renderBuffer.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderBuffer.h
@@ -1,0 +1,200 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef HDLUXCORE_RENDERBUFFER_H
+#define HDLUXCORE_RENDERBUFFER_H
+
+#include "pxr/pxr.h"
+#include "pxr/imaging/hd/renderBuffer.h"
+#include "pxr/base/gf/vec2f.h"
+#include "pxr/base/gf/vec3f.h"
+#include "pxr/base/gf/vec4f.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdLuxCoreRenderBuffer : public HdRenderBuffer
+{
+public:
+    HdLuxCoreRenderBuffer(SdfPath const& id);
+    ~HdLuxCoreRenderBuffer();
+
+    /// Get allocation information from the scene delegate.
+    /// Note: LuxCore overrides this only to stop the render thread before
+    /// potential re-allocation.
+    ///   \param sceneDelegate The scene delegate backing this render buffer.
+    ///   \param renderParam   The renderer-global render param.
+    ///   \param dirtyBits     The invalidation state for this render buffer.
+    virtual void Sync(HdSceneDelegate *sceneDelegate,
+                      HdRenderParam *renderParam,
+                      HdDirtyBits *dirtyBits) override;
+
+    /// Deallocate before deletion.
+    ///   \param renderParam   The renderer-global render param.
+    /// Note: LuxCore overrides this only to stop the render thread before
+    /// potential deallocation.
+    virtual void Finalize(HdRenderParam *renderParam) override;
+
+    /// Allocate a new buffer with the given dimensions and format.
+    ///   \param dimensions   Width, height, and depth of the desired buffer.
+    ///                       (Only depth==1 is supported).
+    ///   \param format       The format of the desired buffer, taken from the
+    ///                       HdFormat enum.
+    ///   \param multisampled Whether the buffer is multisampled.
+    ///   \return             True if the buffer was successfully allocated,
+    ///                       false with a warning otherwise.
+    virtual bool Allocate(GfVec3i const& dimensions,
+                          HdFormat format,
+                          bool multiSampled) override;
+
+    /// Accessor for buffer width.
+    ///   \return The width of the currently allocated buffer.
+    virtual unsigned int GetWidth() const override { return _width; }
+
+    /// Accessor for buffer height.
+    ///   \return The height of the currently allocated buffer.
+    virtual unsigned int GetHeight() const override { return _height; }
+
+    /// Accessor for buffer depth.
+    ///   \return The depth of the currently allocated buffer.
+    virtual unsigned int GetDepth() const override { return 1; }
+
+    /// Accessor for buffer format.
+    ///   \return The format of the currently allocated buffer.
+    virtual HdFormat GetFormat() const override { return _format; }
+
+    /// Accessor for the buffer multisample state.
+    ///   \return Whether the buffer is multisampled or not.
+    virtual bool IsMultiSampled() const override { return _multiSampled; }
+
+    /// Map the buffer for reading/writing. The control flow should be Map(),
+    /// before any I/O, followed by memory access, followed by Unmap() when
+    /// done.
+    ///   \return The address of the buffer.
+//    virtual void* Map() override {
+    virtual uint8_t* Map() override {
+        _mappers++;
+        return _buffer.data();
+    }
+
+    /// Unmap the buffer.
+    virtual void Unmap() override {
+        _mappers--;
+    }
+
+    /// Return whether any clients have this buffer mapped currently.
+    ///   \return True if the buffer is currently mapped by someone.
+    virtual bool IsMapped() const override {
+        return _mappers.load() != 0;
+    }
+
+    /// Is the buffer converged?
+    ///   \return True if the buffer is converged (not currently being
+    ///           rendered to).
+    virtual bool IsConverged() const override {
+        return _converged.load();
+    }
+
+    /// Set the convergence.
+    ///   \param cv Whether the buffer should be marked converged or not.
+    void SetConverged(bool cv) {
+        _converged.store(cv);
+    }
+
+    /// Resolve the sample buffer into final values.
+    virtual void Resolve() override;
+
+    // ---------------------------------------------------------------------- //
+    /// \name I/O helpers
+    // ---------------------------------------------------------------------- //
+
+    /// Write a float, vec2f, vec3f, or vec4f to the renderbuffer.
+    /// This should only be called on a mapped buffer. Extra components will
+    /// be silently discarded; if not enough are provided for the buffer, the
+    /// remainder will be taken as 0.
+    ///   \param pixel         What index to write
+    ///   \param numComponents The arity of the value to write.
+    ///   \param value         A float-valued vector to write. 
+    void Write(GfVec3i const& pixel, size_t numComponents, float const* value);
+
+    /// Write an int, vec2i, vec3i, or vec4i to the renderbuffer.
+    /// This should only be called on a mapped buffer. Extra components will
+    /// be silently discarded; if not enough are provided for the buffer, the
+    /// remainder will be taken as 0.
+    ///   \param pixel         What index to write
+    ///   \param numComponents The arity of the value to write.
+    ///   \param value         An int-valued vector to write. 
+    void Write(GfVec3i const& pixel, size_t numComponents, int const* value);
+
+    /// Clear the renderbuffer with a float, vec2f, vec3f, or vec4f.
+    /// This should only be called on a mapped buffer. Extra components will
+    /// be silently discarded; if not enough are provided for the buffer, the
+    /// remainder will be taken as 0.
+    ///   \param numComponents The arity of the value to write.
+    ///   \param value         A float-valued vector to write. 
+    void Clear(size_t numComponents, float const* value);
+
+    /// Clear the renderbuffer with an int, vec2i, vec3i, or vec4i.
+    /// This should only be called on a mapped buffer. Extra components will
+    /// be silently discarded; if not enough are provided for the buffer, the
+    /// remainder will be taken as 0.
+    ///   \param numComponents The arity of the value to write.
+    ///   \param value         An int-valued vector to write. 
+    void Clear(size_t numComponents, int const* value);
+
+private:
+    // Calculate the needed buffer size, given the allocation parameters.
+    static size_t _GetBufferSize(GfVec2i const& dims, HdFormat format);
+
+    // Return the sample format for the given buffer format. Sample buffers
+    // are always float32 or int32, but with the same number of components
+    // as the base format.
+    static HdFormat _GetSampleFormat(HdFormat format);
+
+    // Release any allocated resources.
+    virtual void _Deallocate() override;
+
+    // Buffer width.
+    unsigned int _width;
+    // Buffer height.
+    unsigned int _height;
+    // Buffer format.
+    HdFormat _format;
+    // Whether the buffer is operating in multisample mode.
+    bool _multiSampled;
+
+    // The resolved output buffer.
+    std::vector<uint8_t> _buffer;
+    // For multisampled buffers: the input write buffer.
+    std::vector<uint8_t> _sampleBuffer;
+    // For multisampled buffers: the sample count buffer.
+    std::vector<uint8_t> _sampleCount;
+
+    // The number of callers mapping this buffer.
+    std::atomic<int> _mappers;
+    // Whether the buffer has been marked as converged.
+    std::atomic<bool> _converged;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDLUXCORE_RENDERBUFFER_H

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
@@ -24,7 +24,6 @@
 #include "pxr/imaging/glf/glew.h"
 #include "pxr/imaging/hdLuxCore/renderDelegate.h"
 
-#include "pxr/imaging/hdLuxCore/config.h"
 #include "pxr/imaging/hdLuxCore/instancer.h"
 #include "pxr/imaging/hdLuxCore/renderParam.h"
 #include "pxr/imaging/hdLuxCore/renderPass.h"
@@ -33,7 +32,6 @@
 #include "pxr/imaging/hd/resourceRegistry.h"
 #include "pxr/imaging/hd/tokens.h"
 
-#include "pxr/imaging/hdLuxCore/mesh.h"
 //XXX: Add other Rprim types later
 #include "pxr/imaging/hd/camera.h"
 //XXX: Add other Sprim types later
@@ -99,13 +97,13 @@ HdLuxCoreRenderDelegate::_Initialize()
     lc_scene = luxcore::Scene::Create();
 
     lc_scene->Parse(
-				luxcore::Property("scene.camera.lookat.orig")(1.f , 6.f , 3.f) <<
-				luxcore::Property("scene.camera.lookat.target")(0.f , 0.f , .5f) <<
-				luxcore::Property("scene.camera.fieldofview")(60.f));
+				luxrays::Property("scene.camera.lookat.orig")(1.f , 6.f , 3.f) <<
+				luxrays::Property("scene.camera.lookat.target")(0.f , 0.f , .5f) <<
+				luxrays::Property("scene.camera.fieldofview")(60.f));
 
     lc_config = luxcore::RenderConfig::Create(
-        Property("renderengine.type")("PATHCPU") <<
-		Property("sampler.type")("RANDOM"),
+        luxrays::Property("renderengine.type")("PATHCPU") <<
+		luxrays::Property("sampler.type")("RANDOM"),
         lc_scene
     );
 
@@ -212,7 +210,7 @@ HdLuxCoreRenderDelegate::CreateRenderPass(HdRenderIndex *index,
                             HdRprimCollection const& collection)
 {
     return HdRenderPassSharedPtr(new HdLuxCoreRenderPass(
-        index, collection, _renderParam, &_sceneVersion));
+        index, collection, &_renderThread, &_renderer, &_sceneVersion));
 }
 
 HdInstancer *
@@ -235,7 +233,7 @@ HdLuxCoreRenderDelegate::CreateRprim(TfToken const& typeId,
                                     SdfPath const& instancerId)
 {
     if (typeId == HdPrimTypeTokens->mesh) {
-        return new HdLuxCoreMesh(rprimId, instancerId);
+        // TODO: add mesh  return new HdLuxCoreMesh(rprimId, instancerId);
     } else {
         TF_CODING_ERROR("Unknown Rprim Type %s", typeId.GetText());
     }

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
@@ -28,8 +28,9 @@
 #include "pxr/imaging/hd/renderDelegate.h"
 #include "pxr/imaging/hd/renderThread.h"
 #include "pxr/base/tf/staticTokens.h"
-#include <luxcore/luxcore.h>
+#include "pxr/imaging/hdLuxCore/renderer.h"
 
+#include <luxcore/luxcore.h>
 #include <mutex>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -244,7 +245,7 @@ private:
 
     // LuxCore initialization routine.
     void _Initialize();
-    luxcore::Properties lc_props;
+    luxrays::Properties lc_props;
     luxcore::RenderConfig *lc_config;
     luxcore::RenderSession *lc_session;
     luxcore::Scene *lc_scene;

--- a/pxr/imaging/plugin/hdLuxCore/renderParam.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderParam.h
@@ -1,0 +1,78 @@
+//
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef HDEMBREE_RENDER_PARAM_H
+#define HDEMBREE_RENDER_PARAM_H
+
+#include "pxr/pxr.h"
+#include "pxr/imaging/hd/renderDelegate.h"
+#include "pxr/imaging/hd/renderThread.h"
+
+#include <luxcore/luxcore.h>
+
+using namespace luxcore;
+
+#include <iostream>
+using namespace std;
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+///
+/// \class HdLuxCoreRenderParam
+///
+/// The render delegate can create an object of type HdRenderParam, to pass
+/// to each prim during Sync(). HdLuxCore uses this class to pass top-level
+/// LuxCore state around.
+/// 
+class HdLuxCoreRenderParam final : public HdRenderParam {
+public:
+    HdLuxCoreRenderParam(Scene *scene,
+                        RenderConfig *config,
+                        RenderSession *session,
+                        std::atomic<int> *sceneVersion)
+        : _scene(scene), _config(config), _session(session), _sceneVersion(sceneVersion)
+        {}
+    virtual ~HdLuxCoreRenderParam() = default;
+
+    /// Accessor for the top-level LuxCore scene.
+    Scene* AcquireSceneForEdit() {
+        cout << "A\n";
+        //_renderThread->StopRender();
+        cout << "B\n";
+        //(*_sceneVersion)++;
+        cout << "C\n";
+        return _scene;
+    }
+
+private:
+    /// A handle to the top-level LuxCore scene.
+    Scene *_scene;
+    RenderConfig *_config;
+    RenderSession *_session;
+    /// A version counter for edits to _scene.
+    std::atomic<int> *_sceneVersion;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDEMBREE_RENDER_PARAM_H

--- a/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Pixar and John Gann
+// Copyright 2016 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -24,17 +24,22 @@
 #include "pxr/imaging/glf/glew.h"
 
 #include "pxr/imaging/hd/renderPassState.h"
-#include "pxr/imaging/HdLuxCore/renderDelegate.h"
-#include "pxr/imaging/HdLuxCore/renderPass.h"
+#include "pxr/imaging/hdLuxCore/renderDelegate.h"
+#include "pxr/imaging/hdLuxCore/renderPass.h"
+
+#include <iostream>
+using namespace std;
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 HdLuxCoreRenderPass::HdLuxCoreRenderPass(HdRenderIndex *index,
                                        HdRprimCollection const &collection,
                                        HdRenderThread *renderThread,
+                                       HdLuxCoreRenderer *renderer,
                                        std::atomic<int> *sceneVersion)
     : HdRenderPass(index, collection)
     , _renderThread(renderThread)
+    , _renderer(renderer)
     , _sceneVersion(sceneVersion)
     , _lastSceneVersion(0)
     , _lastSettingsVersion(0)
@@ -47,10 +52,12 @@ HdLuxCoreRenderPass::HdLuxCoreRenderPass(HdRenderIndex *index,
     , _depthBuffer(SdfPath::EmptyPath())
     , _converged(false)
 {
+    cout << "HdLuxCoreRenderPass::HdLuxCoreRenderPass()\n";
 }
 
 HdLuxCoreRenderPass::~HdLuxCoreRenderPass()
 {
+    cout << "HdLuxCoreRenderPass::~HdLuxCoreRenderPass()\n";
     // Make sure the render thread's not running, in case it's writing
     // to _colorBuffer/_depthBuffer.
     _renderThread->StopRender();
@@ -59,7 +66,21 @@ HdLuxCoreRenderPass::~HdLuxCoreRenderPass()
 bool
 HdLuxCoreRenderPass::IsConverged() const
 {
-    //TODO:Define convergence function for luxcore
+    cout << "HdLuxCoreRenderPass::IsConverged()\n";
+    // If the aov binding array is empty, the render thread is rendering into
+    // _colorBuffer and _depthBuffer.  _converged is set to their convergence
+    // state just before blit, so use that as our answer.
+    if (_aovBindings.size() == 0) {
+        return _converged;
+    }
+
+    // Otherwise, check the convergence of all attachments.
+    for (size_t i = 0; i < _aovBindings.size(); ++i) {
+        if (_aovBindings[i].renderBuffer &&
+            !_aovBindings[i].renderBuffer->IsConverged()) {
+            return false;
+        }
+    }
     return true;
 }
 
@@ -67,7 +88,155 @@ void
 HdLuxCoreRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
                              TfTokenVector const &renderTags)
 {
-   //TODO: Start renderThread
+    cout << "HdLuxCoreRenderPass::_Execute()\n";
+    // XXX: Add collection and renderTags support.
+    // XXX: Add clip planes support.
+
+    // Determine whether the scene has changed since the last time we rendered.
+    bool needStartRender = false;
+    int currentSceneVersion = _sceneVersion->load();
+    if (_lastSceneVersion != currentSceneVersion) {
+        cout << "HdLuxCoreRenderPass::_Execute -> needStartRender = true";
+        needStartRender = true;
+        _lastSceneVersion = currentSceneVersion;
+    }
+
+    // Likewise the render settings.
+    HdRenderDelegate *renderDelegate = GetRenderIndex()->GetRenderDelegate();
+    int currentSettingsVersion = renderDelegate->GetRenderSettingsVersion();
+    if (_lastSettingsVersion != currentSettingsVersion) {
+        _renderThread->StopRender();
+        _lastSettingsVersion = currentSettingsVersion;
+
+        _renderer->SetSamplesToConvergence(
+            renderDelegate->GetRenderSetting<int>(
+                HdRenderSettingsTokens->convergedSamplesPerPixel, 1));
+
+        bool enableAmbientOcclusion =
+            renderDelegate->GetRenderSetting<bool>(
+                HdLuxCoreRenderSettingsTokens->enableAmbientOcclusion, false);
+        if (enableAmbientOcclusion) {
+            _renderer->SetAmbientOcclusionSamples(
+                renderDelegate->GetRenderSetting<int>(
+                    HdLuxCoreRenderSettingsTokens->ambientOcclusionSamples, 0));
+        } else {
+            _renderer->SetAmbientOcclusionSamples(0);
+        }
+
+        _renderer->SetEnableSceneColors(
+            renderDelegate->GetRenderSetting<bool>(
+                HdLuxCoreRenderSettingsTokens->enableSceneColors, true));
+
+        needStartRender = true;
+    }
+
+    GfVec4f vp = renderPassState->GetViewport();
+
+    // Determine whether we need to update the renderer camera.
+    GfMatrix4d view = renderPassState->GetWorldToViewMatrix();
+    GfMatrix4d proj = renderPassState->GetProjectionMatrix();
+    if (_viewMatrix != view || _projMatrix != proj) {
+        _viewMatrix = view;
+        _projMatrix = proj;
+
+        _renderThread->StopRender();
+        _renderer->SetCamera(_viewMatrix, _projMatrix);
+        needStartRender = true;
+    }
+
+    // Determine whether we need to update the renderer viewport.
+    if (_width != vp[2] || _height != vp[3]) {
+        _width = vp[2];
+        _height = vp[3];
+
+        _renderThread->StopRender();
+        _renderer->SetViewport(_width, _height);
+        _colorBuffer.Allocate(GfVec3i(_width, _height, 1), HdFormatUNorm8Vec4,
+                              /*multiSampled=*/true);
+        _depthBuffer.Allocate(GfVec3i(_width, _height, 1), HdFormatFloat32,
+                              /*multiSampled=*/false);
+        needStartRender = true;
+    }
+
+    // Determine whether we need to update the renderer AOV bindings.
+    //
+    // It's possible for the passed in bindings to be empty, but that's
+    // never a legal state for the renderer, so if that's the case we add
+    // a color and depth aov that we can blit to the GL framebuffer.
+    //
+    // If the renderer AOV bindings are empty, force a bindings update so that
+    // we always get a chance to add color/depth on the first time through.
+    HdRenderPassAovBindingVector aovBindings =
+        renderPassState->GetAovBindings();
+    if (_aovBindings != aovBindings || _renderer->GetAovBindings().empty()) {
+        _aovBindings = aovBindings;
+
+        _renderThread->StopRender();
+        if (aovBindings.size() == 0) {
+            // No attachment means we should render to the GL framebuffer
+            HdRenderPassAovBinding colorAov;
+            colorAov.aovName = HdAovTokens->color;
+            colorAov.renderBuffer = &_colorBuffer;
+            colorAov.clearValue =
+                VtValue(GfVec4f(0.0707f, 0.0707f, 0.0707f, 1.0f));
+            aovBindings.push_back(colorAov);
+            HdRenderPassAovBinding depthAov;
+            depthAov.aovName = HdAovTokens->depth;
+            depthAov.renderBuffer = &_depthBuffer;
+            depthAov.clearValue = VtValue(1.0f);
+            aovBindings.push_back(depthAov);
+        }
+        _renderer->SetAovBindings(aovBindings);
+        // In general, the render thread clears aov bindings, but make sure
+        // they are cleared initially on this thread.
+        _renderer->Clear();
+        needStartRender = true;
+    }
+
+    // If there are no AOVs specified, we should blit our local color buffer to
+    // the GL framebuffer.
+    if (_aovBindings.size() == 0) {
+        _converged = _colorBuffer.IsConverged() && _depthBuffer.IsConverged();
+        // To reduce flickering, don't update the compositor until every pixel
+        // has a sample (as determined by depth buffer convergence).
+        if (_depthBuffer.IsConverged()) {
+            _colorBuffer.Resolve();
+            uint8_t *cdata = reinterpret_cast<uint8_t*>(_colorBuffer.Map());
+            if (cdata) {
+                _compositor.UpdateColor(_width, _height, cdata);
+                _colorBuffer.Unmap();
+            }
+            _depthBuffer.Resolve();
+            uint8_t *ddata = reinterpret_cast<uint8_t*>(_depthBuffer.Map());
+            if (ddata) {
+                _compositor.UpdateDepth(_width, _height, ddata);
+                _depthBuffer.Unmap();
+            }
+        }
+
+        // LuxCore does not output opacity at this point so we disable alpha
+        // blending in the compositor so we can see the background color.
+/*
+        GLboolean restoreblendEnabled;
+        glGetBooleanv(GL_BLEND, &restoreblendEnabled);
+        glDisable(GL_BLEND);
+*/
+
+        _compositor.Draw();
+
+/*
+        if (restoreblendEnabled) {
+            glEnable(GL_BLEND);
+        }
+*/
+    }
+
+    // Only start a new render if something in the scene has changed.
+    if (needStartRender) {
+        _converged = false;
+        _renderer->MarkAovBuffersUnconverged();
+        _renderThread->StartRender();
+    }
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdLuxCore/renderPass.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderPass.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Pixar and John Gann
+// Copyright 2016 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -21,14 +21,16 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#ifndef HDLUXCORE_RENDER_PASS_H
-#define HDLUXCORE_RENDER_PASS_H
+#ifndef HDEMBREE_RENDER_PASS_H
+#define HDEMBREE_RENDER_PASS_H
 
 #include "pxr/pxr.h"
 
 #include "pxr/imaging/hd/aov.h"
 #include "pxr/imaging/hd/renderPass.h"
 #include "pxr/imaging/hd/renderThread.h"
+#include "pxr/imaging/hdLuxCore/renderer.h"
+#include "pxr/imaging/hdLuxCore/renderBuffer.h"
 #include "pxr/imaging/hdx/compositor.h"
 
 #include "pxr/base/gf/matrix4d.h"
@@ -53,9 +55,11 @@ public:
     ///   \param index The render index containing scene data to render.
     ///   \param collection The initial rprim collection for this renderpass.
     ///   \param renderThread A handle to the global render thread.
+    ///   \param renderer A handle to the global renderer.
     HdLuxCoreRenderPass(HdRenderIndex *index,
                        HdRprimCollection const &collection,
                        HdRenderThread *renderThread,
+                       HdLuxCoreRenderer *renderer,
                        std::atomic<int> *sceneVersion);
 
     /// Renderpass destructor.
@@ -87,6 +91,9 @@ private:
     // A handle to the render thread.
     HdRenderThread *_renderThread;
 
+    // A handle to the global renderer.
+    HdLuxCoreRenderer *_renderer;
+
     // A reference to the global scene version.
     std::atomic<int> *_sceneVersion;
 
@@ -109,6 +116,11 @@ private:
     // The list of aov buffers this renderpass should write to.
     HdRenderPassAovBindingVector _aovBindings;
 
+    // If no attachments are provided, provide an anonymous renderbuffer for
+    // color and depth output.
+    HdLuxCoreRenderBuffer _colorBuffer;
+    HdLuxCoreRenderBuffer _depthBuffer;
+
     // Were the color/depth buffer converged the last time we blitted them?
     bool _converged;
 
@@ -119,4 +131,4 @@ private:
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
-#endif // HDLUXCORE_RENDER_PASS_H
+#endif // HDEMBREE_RENDER_PASS_H

--- a/pxr/imaging/plugin/hdLuxCore/renderer.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderer.cpp
@@ -1,0 +1,599 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/imaging/hdLuxCore/renderer.h"
+#include "pxr/imaging/hdLuxCore/renderBuffer.h"
+/*
+#include "pxr/imaging/hdLuxCore/config.h"
+#include "pxr/imaging/hdLuxCore/context.h"
+#include "pxr/imaging/hdLuxCore/mesh.h"
+*/
+
+#include "pxr/imaging/hd/perfLog.h"
+
+#include "pxr/base/gf/matrix3f.h"
+#include "pxr/base/gf/vec2f.h"
+#include "pxr/base/work/loops.h"
+
+#include <luxcore/luxcore.h>
+
+#include <chrono>
+#include <thread>
+
+#include <iostream>
+using namespace std;
+
+using namespace luxcore;
+
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdLuxCoreRenderer::HdLuxCoreRenderer()
+    : _aovBindings()
+    , _aovNames()
+    , _aovBindingsNeedValidation(false)
+    , _aovBindingsValid(false)
+    , _width(0)
+    , _height(0)
+    , _viewMatrix(1.0f) // == identity
+    , _projMatrix(1.0f) // == identity
+    , _inverseViewMatrix(1.0f) // == identity
+    , _inverseProjMatrix(1.0f) // == identity
+    , _scene(nullptr)
+    , _samplesToConvergence(0)
+    , _ambientOcclusionSamples(0)
+    , _enableSceneColors(false)
+    , _completedSamples(0)
+{
+    cout << "HdLuxCoreRenderer::HdLuxCoreRenderer() start\n";
+    //luxcore::Init();
+    //_scene = Scene::Create();
+    cout << "HdLuxCoreRenderer::HdLuxCoreRenderer() end\n";
+}
+
+HdLuxCoreRenderer::~HdLuxCoreRenderer()
+{
+    cout << "HdLuxCoreRenderer::~HdLuxCoreRenderer()\n";
+}
+
+void
+HdLuxCoreRenderer::SetScene(Scene *scene)
+{
+    cout << "HdLuxCoreRenderer::SetScene()\n";
+    _scene = scene;
+}
+
+void
+HdLuxCoreRenderer::SetSamplesToConvergence(int samplesToConvergence)
+{
+    cout << "HdLuxCoreRenderer::SetSamplesToConvergence()\n";
+    _samplesToConvergence = samplesToConvergence;
+}
+
+void
+HdLuxCoreRenderer::SetAmbientOcclusionSamples(int ambientOcclusionSamples)
+{
+    cout << "HdLuxCoreRenderer::SetAmbientOcclusionSamples()\n";
+    _ambientOcclusionSamples = ambientOcclusionSamples;
+}
+
+void
+HdLuxCoreRenderer::SetEnableSceneColors(bool enableSceneColors)
+{
+    cout << "HdLuxCoreRenderer::SetEnableSceneColors()\n";
+    _enableSceneColors = enableSceneColors;
+}
+
+void
+HdLuxCoreRenderer::SetViewport(unsigned int width, unsigned int height)
+{
+    cout << "HdLuxCoreRenderer::SetViewport()\n";
+    _width = width;
+    _height = height;
+
+    // Re-validate the attachments, since attachment viewport and
+    // render viewport need to match.
+    _aovBindingsNeedValidation = true;
+}
+
+void
+HdLuxCoreRenderer::SetCamera(const GfMatrix4d& viewMatrix,
+                            const GfMatrix4d& projMatrix)
+{
+    cout << "HdLuxCoreRenderer::SetCamera()\n";
+    _viewMatrix = viewMatrix;
+    _projMatrix = projMatrix;
+    _inverseViewMatrix = viewMatrix.GetInverse();
+    _inverseProjMatrix = projMatrix.GetInverse();
+}
+
+void
+HdLuxCoreRenderer::SetAovBindings(
+    HdRenderPassAovBindingVector const &aovBindings)
+{
+    cout << "HdLuxCoreRenderer::SetAovBindings()\n";
+    _aovBindings = aovBindings;
+    _aovNames.resize(_aovBindings.size());
+    for (size_t i = 0; i < _aovBindings.size(); ++i) {
+        _aovNames[i] = HdParsedAovToken(_aovBindings[i].aovName);
+    }
+
+    // Re-validate the attachments.
+    _aovBindingsNeedValidation = true;
+}
+
+bool
+HdLuxCoreRenderer::_ValidateAovBindings()
+{
+    cout << "HdLuxCoreRenderer::_ValidateAovBindings()\n";
+    if (!_aovBindingsNeedValidation) {
+        return _aovBindingsValid;
+    }
+
+    _aovBindingsNeedValidation = false;
+    _aovBindingsValid = true;
+
+    for (size_t i = 0; i < _aovBindings.size(); ++i) {
+
+        // By the time the attachment gets here, there should be a bound
+        // output buffer.
+        if (_aovBindings[i].renderBuffer == nullptr) {
+            TF_WARN("Aov '%s' doesn't have any renderbuffer bound",
+                    _aovNames[i].name.GetText());
+            _aovBindingsValid = false;
+            continue;
+        }
+
+        if (_aovNames[i].name != HdAovTokens->color &&
+            _aovNames[i].name != HdAovTokens->linearDepth &&
+            _aovNames[i].name != HdAovTokens->depth &&
+            _aovNames[i].name != HdAovTokens->primId &&
+            _aovNames[i].name != HdAovTokens->instanceId &&
+            _aovNames[i].name != HdAovTokens->elementId &&
+            _aovNames[i].name != HdAovTokens->Neye &&
+            _aovNames[i].name != HdAovTokens->normal &&
+            !_aovNames[i].isPrimvar) {
+            TF_WARN("Unsupported attachment with Aov '%s' won't be rendered to",
+                    _aovNames[i].name.GetText());
+        }
+
+        HdFormat format = _aovBindings[i].renderBuffer->GetFormat();
+
+        // depth is only supported for float32 attachments
+        if ((_aovNames[i].name == HdAovTokens->linearDepth ||
+             _aovNames[i].name == HdAovTokens->depth) &&
+            format != HdFormatFloat32) {
+            TF_WARN("Aov '%s' has unsupported format '%s'",
+                    _aovNames[i].name.GetText(),
+                    TfEnum::GetName(format).c_str());
+            _aovBindingsValid = false;
+        }
+
+        // ids are only supported for int32 attachments
+        if ((_aovNames[i].name == HdAovTokens->primId ||
+             _aovNames[i].name == HdAovTokens->instanceId ||
+             _aovNames[i].name == HdAovTokens->elementId) &&
+            format != HdFormatInt32) {
+            TF_WARN("Aov '%s' has unsupported format '%s'",
+                    _aovNames[i].name.GetText(),
+                    TfEnum::GetName(format).c_str());
+            _aovBindingsValid = false;
+        }
+
+        // Normal is only supported for vec3 attachments of float.
+        if ((_aovNames[i].name == HdAovTokens->Neye ||
+             _aovNames[i].name == HdAovTokens->normal) &&
+            format != HdFormatFloat32Vec3) {
+            TF_WARN("Aov '%s' has unsupported format '%s'",
+                    _aovNames[i].name.GetText(),
+                    TfEnum::GetName(format).c_str());
+            _aovBindingsValid = false;
+        }
+
+        // Primvars support vec3 output (though some channels may not be used).
+        if (_aovNames[i].isPrimvar &&
+            format != HdFormatFloat32Vec3) {
+            TF_WARN("Aov 'primvars:%s' has unsupported format '%s'",
+                    _aovNames[i].name.GetText(),
+                    TfEnum::GetName(format).c_str());
+            _aovBindingsValid = false;
+        }
+
+        // color is only supported for vec3/vec4 attachments of float,
+        // unorm, or snorm.
+        if (_aovNames[i].name == HdAovTokens->color) {
+            switch(format) {
+                case HdFormatUNorm8Vec4:
+                case HdFormatUNorm8Vec3:
+                case HdFormatSNorm8Vec4:
+                case HdFormatSNorm8Vec3:
+                case HdFormatFloat32Vec4:
+                case HdFormatFloat32Vec3:
+                    break;
+                default:
+                    TF_WARN("Aov '%s' has unsupported format '%s'",
+                        _aovNames[i].name.GetText(),
+                        TfEnum::GetName(format).c_str());
+                    _aovBindingsValid = false;
+                    break;
+            }
+        }
+
+        // make sure the clear value is reasonable for the format of the
+        // attached buffer.
+        if (!_aovBindings[i].clearValue.IsEmpty()) {
+            HdTupleType clearType =
+                HdGetValueTupleType(_aovBindings[i].clearValue);
+
+            // array-valued clear types aren't supported.
+            if (clearType.count != 1) {
+                TF_WARN("Aov '%s' clear value type '%s' is an array",
+                        _aovNames[i].name.GetText(),
+                        _aovBindings[i].clearValue.GetTypeName().c_str());
+                _aovBindingsValid = false;
+            }
+
+            // color only supports float/double vec3/4
+            if (_aovNames[i].name == HdAovTokens->color &&
+                clearType.type != HdTypeFloatVec3 &&
+                clearType.type != HdTypeFloatVec4 &&
+                clearType.type != HdTypeDoubleVec3 &&
+                clearType.type != HdTypeDoubleVec4) {
+                TF_WARN("Aov '%s' clear value type '%s' isn't compatible",
+                        _aovNames[i].name.GetText(),
+                        _aovBindings[i].clearValue.GetTypeName().c_str());
+                _aovBindingsValid = false;
+            }
+
+            // only clear float formats with float, int with int, float3 with
+            // float3.
+            if ((format == HdFormatFloat32 && clearType.type != HdTypeFloat) ||
+                (format == HdFormatInt32 && clearType.type != HdTypeInt32) ||
+                (format == HdFormatFloat32Vec3 &&
+                 clearType.type != HdTypeFloatVec3)) {
+                TF_WARN("Aov '%s' clear value type '%s' isn't compatible with"
+                        " format %s",
+                        _aovNames[i].name.GetText(),
+                        _aovBindings[i].clearValue.GetTypeName().c_str(),
+                        TfEnum::GetName(format).c_str());
+                _aovBindingsValid = false;
+            }
+        }
+
+        // make sure the attachment and render viewports match.
+        // XXX: we could possibly relax this in the future.
+        if (_aovBindings[i].renderBuffer->GetWidth() != _width ||
+            _aovBindings[i].renderBuffer->GetHeight() != _height) {
+            TF_WARN("Aov '%s' viewport (%u, %u) doesn't match render viewport"
+                    " (%u, %u)",
+                    _aovNames[i].name.GetText(),
+                    _aovBindings[i].renderBuffer->GetWidth(),
+                    _aovBindings[i].renderBuffer->GetHeight(),
+                    _width, _height);
+
+            // if the viewports don't match, we block rendering.
+            _aovBindingsValid = false;
+        }
+    }
+
+    return _aovBindingsValid;
+}
+
+/* static */
+GfVec4f
+HdLuxCoreRenderer::_GetClearColor(VtValue const& clearValue)
+{
+    cout << "HdLuxCoreRenderer::_GetClearColor()\n";
+    HdTupleType type = HdGetValueTupleType(clearValue);
+    if (type.count != 1) {
+        return GfVec4f(0.0f, 0.0f, 0.0f, 1.0f);
+    }
+
+    switch(type.type) {
+        case HdTypeFloatVec3:
+        {
+            GfVec3f f =
+                *(static_cast<const GfVec3f*>(HdGetValueData(clearValue)));
+            return GfVec4f(f[0], f[1], f[2], 1.0f);
+        }
+        case HdTypeFloatVec4:
+        {
+            GfVec4f f =
+                *(static_cast<const GfVec4f*>(HdGetValueData(clearValue)));
+            return GfVec4f(f[0], f[1], f[2], 1.0f);
+        }
+        case HdTypeDoubleVec3:
+        {
+            GfVec3d f =
+                *(static_cast<const GfVec3d*>(HdGetValueData(clearValue)));
+            return GfVec4f(f[0], f[1], f[2], 1.0f);
+        }
+        case HdTypeDoubleVec4:
+        {
+            GfVec4d f =
+                *(static_cast<const GfVec4d*>(HdGetValueData(clearValue)));
+            return GfVec4f(f[0], f[1], f[2], 1.0f);
+        }
+        default:
+            return GfVec4f(0.0f, 0.0f, 0.0f, 1.0f);
+    }
+}
+
+void
+HdLuxCoreRenderer::Clear()
+{
+    cout << "HdLuxCoreRenderer::Clear()\n";
+    if (!_ValidateAovBindings()) {
+        return;
+    }
+
+    for (size_t i = 0; i < _aovBindings.size(); ++i) {
+        if (_aovBindings[i].clearValue.IsEmpty()) {
+            continue;
+        }
+
+        HdLuxCoreRenderBuffer *rb = 
+            static_cast<HdLuxCoreRenderBuffer*>(_aovBindings[i].renderBuffer);
+
+        rb->Map();
+        if (_aovNames[i].name == HdAovTokens->color) {
+            GfVec4f clearColor = _GetClearColor(_aovBindings[i].clearValue);
+            rb->Clear(4, clearColor.data());
+        } else if (rb->GetFormat() == HdFormatInt32) {
+            int32_t clearValue = _aovBindings[i].clearValue.Get<int32_t>();
+            rb->Clear(1, &clearValue);
+        } else if (rb->GetFormat() == HdFormatFloat32) {
+            float clearValue = _aovBindings[i].clearValue.Get<float>();
+            rb->Clear(1, &clearValue);
+        } else if (rb->GetFormat() == HdFormatFloat32Vec3) {
+            GfVec3f clearValue = _aovBindings[i].clearValue.Get<GfVec3f>();
+            rb->Clear(3, clearValue.data());
+        } // else, _ValidateAovBindings would have already warned.
+
+        rb->Unmap();
+        rb->SetConverged(false);
+    }
+}
+
+void
+HdLuxCoreRenderer::MarkAovBuffersUnconverged()
+{
+    cout << "HdLuxCoreRenderer::MarkAovBuffersUnconverged()\n";
+    for (size_t i = 0; i < _aovBindings.size(); ++i) {
+        HdLuxCoreRenderBuffer *rb =
+            static_cast<HdLuxCoreRenderBuffer*>(_aovBindings[i].renderBuffer);
+        rb->SetConverged(false);
+    }
+}
+
+int
+HdLuxCoreRenderer::GetCompletedSamples() const
+{
+    cout << "HdLuxCoreRenderer::GetCompletedSamples()\n";
+    return _completedSamples.load();
+}
+
+void
+HdLuxCoreRenderer::Render(HdRenderThread *renderThread)
+{
+    cout << "HdLuxCoreRenderer::Render()\n";
+    return;
+/*
+    _completedSamples.store(0);
+
+    // Commit any pending changes to the scene.
+    //rtcCommit(_scene);
+
+    if (!_ValidateAovBindings()) {
+        // We aren't going to render anything. Just mark all AOVs as converged
+        // so that we will stop rendering.
+        for (size_t i = 0; i < _aovBindings.size(); ++i) {
+            HdLuxCoreRenderBuffer *rb = static_cast<HdLuxCoreRenderBuffer*>(
+                _aovBindings[i].renderBuffer);
+            rb->SetConverged(true);
+        }
+        // XXX:validation
+        TF_WARN("Could not validate Aovs. Render will not complete");
+        return;
+    }
+
+    // Map all of the attachments.
+    for (size_t i = 0; i < _aovBindings.size(); ++i) {
+        static_cast<HdLuxCoreRenderBuffer*>(
+            _aovBindings[i].renderBuffer)->Map();
+    }
+
+    // Render the image. Each pass through the loop adds a sample per pixel
+    // (with jittered ray direction); the longer the loop runs, the less noisy
+    // the image becomes. We add a cancellation point once per loop.
+    //
+    // We consider the image converged after N samples, which is a convenient
+    // and simple heuristic.
+    for (int i = 0; i < _samplesToConvergence; ++i) {
+        // Pause point.
+        while (renderThread->IsPauseRequested()) {
+            if (renderThread->IsStopRequested()) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        // Cancellation point.
+        if (renderThread->IsStopRequested()) {
+            break;
+        }
+
+        unsigned int tileSize = HdLuxCoreConfig::GetInstance().tileSize;
+        const unsigned int numTilesX = (_width + tileSize-1) / tileSize;
+        const unsigned int numTilesY = (_height + tileSize-1) / tileSize;
+
+        // Render by scheduling square tiles of the sample buffer in a parallel
+        // for loop.
+        WorkParallelForN(numTilesX*numTilesY,
+            std::bind(&HdLuxCoreRenderer::_RenderTiles, this,
+                (i == 0) ? nullptr : renderThread,
+                std::placeholders::_1, std::placeholders::_2));
+
+        // After the first pass, mark the single-sampled attachments as
+        // converged and unmap them. If there are no multisampled attachments,
+        // we are done.
+        if (i == 0) {
+            bool moreWork = false;
+            for (size_t i = 0; i < _aovBindings.size(); ++i) {
+                HdLuxCoreRenderBuffer *rb = static_cast<HdLuxCoreRenderBuffer*>(
+                    _aovBindings[i].renderBuffer);
+                if (rb->IsMultiSampled()) {
+                    moreWork = true;
+                }
+            }
+            if (!moreWork) {
+                _completedSamples.store(i+1);
+                break;
+            }
+        }
+
+        // Track the number of completed samples for external consumption.
+        _completedSamples.store(i+1);
+
+        // Cancellation point.
+        if (renderThread->IsStopRequested()) {
+            break;
+        }
+    }
+
+    // Mark the multisampled attachments as converged and unmap all buffers.
+    for (size_t i = 0; i < _aovBindings.size(); ++i) {
+        HdLuxCoreRenderBuffer *rb = static_cast<HdLuxCoreRenderBuffer*>(
+            _aovBindings[i].renderBuffer);
+        rb->Unmap();
+        rb->SetConverged(true);
+    }
+*/
+}
+
+void
+HdLuxCoreRenderer::_RenderTiles(HdRenderThread *renderThread,
+                               size_t tileStart, size_t tileEnd)
+{
+    cout << "HdLuxCoreRenderer::_RenderTiles()\n";
+    return;
+/*
+    unsigned int tileSize =
+        HdLuxCoreConfig::GetInstance().tileSize;
+    const unsigned int numTilesX = (_width + tileSize-1) / tileSize;
+
+    // Initialize the RNG for this tile (each tile creates one as
+    // a lazy way to do thread-local RNGs).
+    size_t seed = std::chrono::system_clock::now().time_since_epoch().count();
+    boost::hash_combine(seed, tileStart);
+    std::default_random_engine random(seed);
+
+    // Create a uniform distribution for jitter calculations.
+    std::uniform_real_distribution<float> uniform_dist(0.0f, 1.0f);
+    std::function<float()> uniform_float = std::bind(uniform_dist, random);
+
+    // _RenderTiles gets a range of tiles; iterate through them.
+    for (unsigned int tile = tileStart; tile < tileEnd; ++tile) {
+
+        // Cancellation point.
+        if (renderThread && renderThread->IsStopRequested()) {
+            break;
+        }
+
+        // Compute the pixel location of tile boundaries.
+        const unsigned int tileY = tile / numTilesX;
+        const unsigned int tileX = tile - tileY * numTilesX; 
+        // (Above is equivalent to: tileX = tile % numTilesX)
+        const unsigned int x0 = tileX * tileSize;
+        const unsigned int y0 = tileY * tileSize;
+        // Clamp far boundaries to the viewport, in case tileSize doesn't
+        // neatly divide _width or _height.
+        const unsigned int x1 = std::min(x0+tileSize, _width);
+        const unsigned int y1 = std::min(y0+tileSize, _height);
+
+        // Loop over pixels casting rays.
+        for (unsigned int y = y0; y < y1; ++y) {
+            for (unsigned int x = x0; x < x1; ++x) {
+
+                // Jitter the camera ray direction.
+                GfVec2f jitter(0.0f, 0.0f);
+                if (HdLuxCoreConfig::GetInstance().jitterCamera) {
+                    jitter = GfVec2f(uniform_float(), uniform_float());
+                }
+
+                // Un-transform the pixel's NDC coordinates through the
+                // projection matrix to get the trace of the camera ray in the
+                // near plane.
+                GfVec3f ndc = GfVec3f(2 * ((x + jitter[0]) / _width) - 1,
+                                      2 * ((y + jitter[1]) / _height) - 1,
+                                      -1);
+                GfVec3f nearPlaneTrace = _inverseProjMatrix.Transform(ndc);
+
+                GfVec3f origin;
+                GfVec3f dir;
+
+                bool isOrthographic = round(_projMatrix[3][3]) == 1;
+                if (isOrthographic) {
+                    // During orthographic projection: trace parallel rays
+                    // from the near plane trace.
+                    origin = nearPlaneTrace;
+                    dir = GfVec3f(0,0,-1);
+                } else {
+                    // Otherwise, assume this is a perspective projection;
+                    // project from the camera origin through the
+                    // near plane trace.
+                    origin = GfVec3f(0,0,0);
+                    dir = nearPlaneTrace;
+                }
+                // Transform camera rays to world space.
+                origin = _inverseViewMatrix.Transform(origin);
+                dir = _inverseViewMatrix.TransformDir(dir).GetNormalized();
+
+                // Trace the ray.
+                _TraceRay(x, y, origin, dir, random);
+            }
+        }
+    }
+*/
+}
+
+/// Generate a random cosine-weighted direction ray (in the hemisphere
+/// around <0,0,1>).  The input is a pair of uniformly distributed random
+/// numbers in the range [0,1].
+///
+/// The algorithm here is to generate a random point on the disk, and project
+/// that point to the unit hemisphere.
+static GfVec3f
+_CosineWeightedDirection(GfVec2f const& uniform_float)
+{
+    cout << "_CosineWeightedDirection()\n";
+    GfVec3f dir;
+    float theta = 2.0f * M_PI * uniform_float[0];
+    float eta = uniform_float[1];
+    float sqrteta = sqrtf(eta);
+    dir[0] = cosf(theta) * sqrteta;
+    dir[1] = sinf(theta) * sqrteta;
+    dir[2] = sqrtf(1.0f-eta);
+    return dir;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdLuxCore/renderer.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderer.h
@@ -1,0 +1,211 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef HDLUXCORE_RENDERER_H
+#define HDLUXCORE_RENDERER_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hd/renderThread.h"
+#include "pxr/imaging/hd/renderPassState.h"
+#include "pxr/imaging/hd/tokens.h"
+
+#include "pxr/base/gf/matrix4d.h"
+
+#include <random>
+#include <atomic>
+
+#include <luxcore/luxcore.h>
+
+using namespace luxcore;
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// \class HdLuxCoreRenderer
+///
+/// HdLuxCoreRenderer implements a renderer on top of LuxCore's raycasting
+/// abilities.  This is currently a very simple renderer.  It breaks the
+/// framebuffer into tiles for multithreading; sends out jittered camera
+/// rays; and implements the following shading:
+///  - Colors via the "color" primvar.
+///  - Lighting via N dot Camera-ray, simulating a point light at the camera
+///    origin.
+///  - Ambient occlusion.
+///
+class HdLuxCoreRenderer final {
+public:
+    /// Renderer constructor.
+    HdLuxCoreRenderer();
+
+    /// Renderer destructor.
+    ~HdLuxCoreRenderer();
+
+    /// Set the LuxCore scene that this renderer should raycast into.
+    ///   \param scene The LuxCore scene to use.
+    void SetScene(Scene *scene);
+
+    /// Specify a new viewport size for the sample/color buffer.
+    ///   \param width The new viewport width.
+    ///   \param height The new viewport height.
+    void SetViewport(unsigned int width, unsigned int height);
+
+    /// Set the camera to use for rendering.
+    ///   \param viewMatrix The camera's world-to-view matrix.
+    ///   \param projMatrix The camera's view-to-NDC projection matrix.
+    void SetCamera(const GfMatrix4d& viewMatrix, const GfMatrix4d& projMatrix);
+
+    /// Set the aov bindings to use for rendering.
+    ///   \param aovBindings A list of aov bindings.
+    void SetAovBindings(HdRenderPassAovBindingVector const &aovBindings);
+
+    /// Get the aov bindings being used for rendering.
+    ///   \return the current aov bindings.
+    HdRenderPassAovBindingVector const& GetAovBindings() const {
+        return _aovBindings;
+    }
+
+    /// Set how many samples to render before considering an image converged.
+    ///   \param samplesToConvergence How many samples are needed, per-pixel,
+    ///                               before the image is considered finished.
+    void SetSamplesToConvergence(int samplesToConvergence);
+
+    /// Set how many samples to use for ambient occlusion.
+    ///   \param ambientOcclusionSamples How many samples are needed for
+    ///                                  ambient occlusion? 0 = disable.
+    void SetAmbientOcclusionSamples(int ambientOcclusionSamples);
+
+    /// Sets whether to use scene colors while rendering.
+    ///   \param enableSceneColors Whether drawing should sample color, or draw
+    ///                            everything as white.
+    void SetEnableSceneColors(bool enableSceneColors);
+
+    /// Rendering entrypoint: add one sample per pixel to the whole sample
+    /// buffer, and then loop until the image is converged.  After each pass,
+    /// the image will be resolved into a color buffer.
+    ///   \param renderThread A handle to the render thread, used for checking
+    ///                       for cancellation and locking the color buffer.
+    void Render(HdRenderThread *renderThread);
+
+    /// Clear the bound aov buffers (typically before rendering).
+    void Clear();
+
+    /// Mark the aov buffers as unconverged.
+    void MarkAovBuffersUnconverged();
+
+    /// Get the number of samples completed so far.
+    int GetCompletedSamples() const;
+
+private:
+    // Validate the internal consistency of aov bindings provided to
+    // SetAovBindings. If the aov bindings are invalid, this will issue
+    // appropriate warnings. If the function returns false, Render() will fail
+    // early.
+    //
+    // This function thunks itself using _aovBindingsNeedValidation and
+    // _aovBindingsValid.
+    //   \return True if the aov bindings are valid for rendering.
+    bool _ValidateAovBindings();
+
+    // Return the clear color to use for the given VtValue.
+    static GfVec4f _GetClearColor(VtValue const& clearValue);
+
+    // Render square tiles of pixels. This function is one unit of threadpool
+    // work. For each tile, iterate over pixels in the tile, generating camera
+    // rays, and following them/calculating color with _TraceRay. This function
+    // renders all tiles between tileStart and tileEnd.
+    void _RenderTiles(HdRenderThread *renderThread,
+                      size_t tileStart, size_t tileEnd);
+
+    // Cast a ray into the scene and if it hits an object, write to the bound
+    // aov buffers.
+    void _TraceRay(unsigned int x, unsigned int y,
+                   GfVec3f const& origin, GfVec3f const& dir,
+                   std::default_random_engine &random);
+
+/*
+    // Compute the color at the given ray hit.
+    GfVec4f _ComputeColor(RTCRay const& rayHit,
+                          std::default_random_engine &random,
+                          GfVec4f const& clearColor);
+    // Compute the depth at the given ray hit.
+    bool _ComputeDepth(RTCRay const& rayHit, float *depth, bool ndc);
+    // Compute the given ID at the given ray hit.
+    bool _ComputeId(RTCRay const& rayHit, TfToken const& idType, int32_t *id);
+    // Compute the normal at the given ray hit.
+    bool _ComputeNormal(RTCRay const& rayHit, GfVec3f *normal, bool eye);
+    // Compute a primvar at the given ray hit.
+    bool _ComputePrimvar(RTCRay const& rayHit, TfToken const& primvar,
+        GfVec3f *value);
+*/
+
+    // Compute the ambient occlusion term at a given point by firing rays
+    // from "position" in the hemisphere centered on "normal"; the occlusion
+    // factor is the fraction of those rays that are visible.
+    //
+    // Modulating surface color by occlusionFactor is similar to taking
+    // the light contribution of an infinitely far, pure white dome light.
+    float _ComputeAmbientOcclusion(GfVec3f const& position,
+                                   GfVec3f const& normal,
+                                   std::default_random_engine &random);
+
+    // The bound aovs for this renderer.
+    HdRenderPassAovBindingVector _aovBindings;
+    // Parsed AOV name tokens.
+    HdParsedAovTokenVector _aovNames;
+
+    // Do the aov bindings need to be re-validated?
+    bool _aovBindingsNeedValidation;
+    // Are the aov bindings valid?
+    bool _aovBindingsValid;
+
+    // The width of the viewport we're rendering into.
+    unsigned int _width;
+    // The height of the viewport we're rendering into.
+    unsigned int _height;
+
+    // View matrix: world space to camera space.
+    GfMatrix4d _viewMatrix;
+    // Projection matrix: camera space to NDC space.
+    GfMatrix4d _projMatrix;
+    // The inverse view matrix: camera space to world space.
+    GfMatrix4d _inverseViewMatrix;
+    // The inverse projection matrix: NDC space to camera space.
+    GfMatrix4d _inverseProjMatrix;
+
+    // Our handle to the LuxCore scene.
+    Scene *_scene;
+
+    // How many samples should we render to convergence?
+    int _samplesToConvergence;
+    // How many samples should we use for ambient occlusion?
+    int _ambientOcclusionSamples;
+    // Should we enable scene colors?
+    bool _enableSceneColors;
+
+    // How many samples have been completed.
+    std::atomic<int> _completedSamples;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDLUXCORE_RENDERER_H

--- a/pxr/imaging/plugin/hdLuxCore/rendererPlugin.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/rendererPlugin.cpp
@@ -21,10 +21,14 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#include "pxr/imaging/hdLuxCore/rendererPlugin.h"
 
+#include "pxr/imaging/hdLuxCore/rendererPlugin.h"
 #include "pxr/imaging/hdx/rendererPluginRegistry.h"
 #include "pxr/imaging/hdLuxCore/renderDelegate.h"
+
+#include <iostream>
+using namespace std;
+
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -37,14 +41,8 @@ TF_REGISTRY_FUNCTION(TfType)
 HdRenderDelegate*
 HdLuxCoreRendererPlugin::CreateRenderDelegate()
 {
+    cout << "Starting HdLuxCoreRendererPlugin::CreateRenderDelegate()\n";
     return new HdLuxCoreRenderDelegate();
-}
-
-HdRenderDelegate*
-HdLuxCoreRendererPlugin::CreateRenderDelegate(
-    HdRenderSettingsMap const& settingsMap)
-{
-    return new HdLuxCoreRenderDelegate(settingsMap);
 }
 
 void
@@ -58,6 +56,7 @@ HdLuxCoreRendererPlugin::IsSupported() const
 {
     // Nothing more to check for now, we assume if the plugin loads correctly
     // it is supported.
+    cout << "Starting HdLuxCoreRendererPlugin::IsSupported()\n";
     return true;
 }
 

--- a/pxr/imaging/plugin/hdLuxCore/rendererPlugin.h
+++ b/pxr/imaging/plugin/hdLuxCore/rendererPlugin.h
@@ -14,9 +14,6 @@ public:
 
     virtual HdRenderDelegate *CreateRenderDelegate() override;
 
-    virtual HdRenderDelegate *CreateRenderDelegate(
-        HdRenderSettingsMap const& settingsMap) override;
-
     virtual void DeleteRenderDelegate(
         HdRenderDelegate *renderDelegate) override;
     

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,22 @@
+LuxCore USD Hydra delegate
+===========================
+
+This plugin allows fast GPU or CPU accelerated viewport rendering by the open source LuxCore rendererer for the USD and Hydra system
+
+For more details on USD, please visit the web site [here](http://openusd.org).
+
+Prerequisites
+-----------------------------
+
+#### Common
+* **LuxCore SDK 2.1**
+* **USD build / tree**
+
+
+
+----
+## Current Status
+Currently the delegate will build against an existing USD installation and has all the necessary placeholder classes and methods to respond to the calls made by the hydra framework.  At this time these placeholder methods make an entry into USD's logging system
+
+##Further Work Required
+The most pressing issue at this time is to parse USD scene objects into meshes readable by LuxCore, and to output the rendered meshes into a GL buffer displayable by the USD Viewport

--- a/script/build_windows.bat
+++ b/script/build_windows.bat
@@ -1,14 +1,16 @@
 set USD_ROOT=c:\usd
-set LUXCORE_ROOT=c:/john/luxcorerender-v2.2-win64-opencl-sdk
+set LUXCORE_ROOT=c:\masters\luxcorerender-v2.2-win64-opencl-sdk
+set LUXCORERENDERUSD_REPO=c:\masters\LuxCoreRenderUSD
+
 rem "Copying LuxCore DLL's to usdview's binary directory"
-copy /Y c:\john\luxcorerender-v2.2-win64-opencl-sdk\lib\*.dll c:\usd\bin
+copy /Y %LUXCORE_ROOT%\lib\*.dll c:\usd\bin
 
 rmdir /s /q build
 cmake -Bbuild . -G "Visual Studio 15 2017 Win64"
 cd build
 cmake --build . --config Release
 cd ..
-copy C:\Users\user\repos\LuxCoreRenderUSD\build\pxr\imaging\plugin\hdLuxCore\Release\*.dll c:\usd\plugin\usd
+copy %LUXCORERENDERUSD_REPO%\build\pxr\imaging\plugin\hdLuxCore\Release\*.dll c:\usd\plugin\usd
 mkdir c:\usd\plugin\usd\hdLuxCore
 mkdir c:\usd\plugin\usd\hdLuxCore\resources
-copy C:\Users\user\repos\LuxCoreRenderUSD\pxr\imaging\plugin\hdLuxCore\PlugInfo.json c:\usd\plugin\usd\hdluxcore\resources
+copy %LUXCORERENDERUSD_REPO%\pxr\imaging\plugin\hdLuxCore\PlugInfo.json c:\usd\plugin\usd\hdluxcore\resources

--- a/script/build_windows.bat
+++ b/script/build_windows.bat
@@ -1,0 +1,14 @@
+set USD_ROOT=c:\usd
+set LUXCORE_ROOT=c:/john/luxcorerender-v2.2-win64-opencl-sdk
+rem "Copying LuxCore DLL's to usdview's binary directory"
+copy /Y c:\john\luxcorerender-v2.2-win64-opencl-sdk\lib\*.dll c:\usd\bin
+
+rmdir /s /q build
+cmake -Bbuild . -G "Visual Studio 15 2017 Win64"
+cd build
+cmake --build . --config Release
+cd ..
+copy C:\Users\user\repos\LuxCoreRenderUSD\build\pxr\imaging\plugin\hdLuxCore\Release\*.dll c:\usd\plugin\usd
+mkdir c:\usd\plugin\usd\hdLuxCore
+mkdir c:\usd\plugin\usd\hdLuxCore\resources
+copy C:\Users\user\repos\LuxCoreRenderUSD\pxr\imaging\plugin\hdLuxCore\PlugInfo.json c:\usd\plugin\usd\hdluxcore\resources

--- a/script/test.bat
+++ b/script/test.bat
@@ -1,1 +1,1 @@
-usdview --renderer LuxCore c:\users\user\repos\USD\extras\usd\tutorials\helloworld\helloworld.usda
+usdview --renderer LuxCore c:\masters\USD\extras\usd\tutorials\helloworld\helloworld.usda

--- a/script/test.bat
+++ b/script/test.bat
@@ -1,0 +1,1 @@
+usdview --renderer LuxCore c:\users\user\repos\USD\extras\usd\tutorials\helloworld\helloworld.usda


### PR DESCRIPTION
This PR adds initial build functionality for Windows 10.  The plugin is linked with LuxCore, compiled into a dll, and installed into a pre-set path.

The following changes were made:
* Add CMakeLists.txt build files for Windows 10.
* Add Windows 10 DOS build and test script.
* Replace current renderPass and renderDelegate boilerplate with Embree boilerplate.
* Add a boilerplate renderer and renderBuffer.
* Add debugging statements.