### PR TITLE
Add Windows 10 build instructions to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vs/
 build/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -10,14 +10,18 @@ Prerequisites
 
 #### Common
 * **LuxCore SDK 2.1**
-* **USD build / tree**
+* **USD 19.07**
+* **Windows 10 with Visual Studio 2017 (Linux is coming soon)**
+* **Cmake 3.16.0 or later**
 
-
-
+#### How to Build For Windows 10
+1. Download the USD release and build it into the folder C:\masters\USD
+2. Download the LuxCore SDK and extract the zip into C:\masters\luxcorerender-v2.2-win64-opencl-sdk
+3. From the root of this repo, run script\build_windows.bat
+4. If the install proceeded correctly, you should now be able to run USDview and select LuxCore as your renderer
 ----
 ## Current Status
 Currently the delegate will build against an existing USD installation and has all the necessary placeholder classes and methods to respond to the calls made by the hydra framework.  At this time these placeholder methods make an entry into USD's logging system
 
-----
-## Further Work Required
+##Further Work Required
 The most pressing issue at this time is to parse USD scene objects into meshes readable by LuxCore, and to output the rendered meshes into a GL buffer displayable by the USD Viewport


### PR DESCRIPTION
Adds Windows 10 build instructions and SDK versions to the README. 
Adds Visual Studio Code's temp file folder to the .gitignore. 