### PR TITLE
Add explicit openGL support to the build

### DIFF
--- a/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
@@ -34,6 +34,7 @@ pxr_plugin(hdLuxCore
         ${RIF_LIBRARY}
         ${OPENSUBDIV_LIBRARIES}
         ${TBB_tbb_LIBRARY}
+        ${OPENGL_gl_LIBRARY}
         LuxCore
 
     INCLUDE_DIRS


### PR DESCRIPTION
This PR adds openGL support through the CMake build process.