### PR TITLE
Add basic mesh functionality to the plugin

### DIFF
--- a/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
@@ -52,6 +52,7 @@ pxr_plugin(hdLuxCore
         renderPass
         renderer
         renderBuffer
+        mesh
 
     PUBLIC_HEADERS
         renderParam.h

--- a/pxr/imaging/plugin/hdLuxCore/instancer.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/instancer.cpp
@@ -77,6 +77,7 @@ HdLuxCoreInstancer::_SyncPrimvars()
 
     HdChangeTracker &changeTracker = 
         GetDelegate()->GetRenderIndex().GetChangeTracker();
+
     SdfPath const& id = GetId();
 
     // Use the double-checked locking pattern to check if this instancer's
@@ -129,7 +130,6 @@ HdLuxCoreInstancer::ComputeInstanceTransforms(SdfPath const &prototypeId)
     //     scale(index) * instanceTransform(index)
     // }
     // If any transform isn't provided, it's assumed to be the identity.
-
     GfMatrix4d instancerTransform =
         GetDelegate()->GetInstancerTransform(GetId());
     VtIntArray instanceIndices =

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
@@ -29,6 +29,7 @@
 #include "pxr/imaging/hd/renderThread.h"
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/imaging/hdLuxCore/renderer.h"
+#include "pxr/imaging/hdLuxCore/mesh.h"
 
 #include <luxcore/luxcore.h>
 #include <mutex>

--- a/pxr/imaging/plugin/hdLuxCore/renderPass.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderPass.h
@@ -113,6 +113,9 @@ private:
     // The projection matrix: camera space to NDC space
     GfMatrix4d _projMatrix;
 
+    GfMatrix4d _inverseViewMatrix;
+    GfMatrix4d _inverseProjectionMatrix;
+
     // The list of aov buffers this renderpass should write to.
     HdRenderPassAovBindingVector _aovBindings;
 


### PR DESCRIPTION
This PR adds basic functionality to convert meshes defined in USD to meshes understandable by the LuxCore renderer. Additionally, updates have been made to the camera positioning logic to more fully integrate it with LuxCore.

![hdluxcore_first_working_mesh](https://user-images.githubusercontent.com/14242682/75404201-b0b67700-58be-11ea-97f2-a881d885c0b3.png)


