### PR TITLE
Rearchitect renderPass to make LuxCore rendering thread-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Prerequisites
 6. A test script is available from this repo at script/test.sh
 ----
 ## Current Status
-Currently the delegate will build against an existing USD installation and has all the necessary placeholder classes and methods to respond to the calls made by the hydra framework.  At this time these placeholder methods log trace output to the console.
+Currently the delegate will build against an existing USD installation and has all the necessary classes and methods to respond to the calls made by the hydra framework.  The delegate can render can currently render meshes and position the camera based on the USD scene description file.
 
-##Further Work Required
-The most pressing issue at this time is to parse USD scene objects into meshes readable by LuxCore, and to output the rendered meshes into a GL buffer displayable by the USD Viewport
+## Credits
+Thanks to Jereon Lapre of the California Academy of Sciences for the sample USDA file test/asset/geo_GridSphereLightCam.004.usd_scene.usda used for our rendering tests.

--- a/pxr/imaging/plugin/hdLuxCore/mesh.h
+++ b/pxr/imaging/plugin/hdLuxCore/mesh.h
@@ -116,6 +116,12 @@ public:
     ///                      embree state.
     virtual void Finalize(HdRenderParam *renderParam) override;
 
+    bool CreateLuxCoreTriangleMesh(HdRenderParam *renderParam);
+
+    virtual VtMatrix4dArray GetTransforms() const {
+        return _transforms;
+    }
+
 protected:
     // Initialize the given representation of this Rprim.
     // This is called prior to syncing the prim, the first time the repr
@@ -145,14 +151,6 @@ protected:
     virtual HdDirtyBits _PropagateDirtyBits(HdDirtyBits bits) const override;
 
 private:
-    // Populate the LuxCore geometry object based on scene data.
-    void _PopulateLuxCoreMesh(HdRenderParam *renderParam,
-                         HdSceneDelegate *sceneDelegate,
-                         HdDirtyBits *dirtyBits,
-                         HdMeshReprDesc const &desc);
-
-    void _CreateLuxCoreTriangleMesh(HdRenderParam *renderParam);
-
     // Populate _primvarSourceMap (our local cache of primvar data) based on
     // authored scene data.
     // Primvars will be turned into samplers in _PopulateRtMesh,
@@ -181,10 +179,6 @@ private:
     // Cached scene data. VtArrays are reference counted, so as long as we
     // only call const accessors keeping them around doesn't incur a buffer
     // copy.
-    HdMeshTopology _topology;
-    GfMatrix4f _transform;
-    VtVec3fArray _points;
-
     // Derived scene data:
     // - _triangulatedIndices holds a triangulation of the source topology,
     //   which can have faces of arbitrary arity.
@@ -192,7 +186,7 @@ private:
     //   the triangulated topology) to authored face index.
     // - _computedNormals holds per-vertex normals computed as an average of
     //   adjacent face normals.
-    VtVec3iArray _triangulatedIndices;
+
     VtIntArray _trianglePrimitiveParams;
     VtVec3fArray _computedNormals;
 
@@ -221,11 +215,16 @@ private:
     };
     TfHashMap<TfToken, PrimvarSource, TfToken::HashFunctor> _primvarSourceMap;
 
-    // An object used to manage allocation of embree user vertex buffers to
-    // primvars.
-   // HdEmbreeRTCBufferAllocator _embreeBufferAllocator;
+    size_t _total_instances;
 
-   size_t _total_instances;
+    HdDirtyBits *_dirtyBits;
+    HdMeshReprDesc _desc;
+    HdSceneDelegate *_sceneDelegate;
+    VtMatrix4dArray _transforms;
+    VtVec3fArray _points;
+    VtVec3iArray _triangulatedIndices;
+    HdMeshTopology _topology;
+    GfMatrix4f _transform;
 
     // This class does not support copying.
     HdLuxCoreMesh(const HdLuxCoreMesh&)             = delete;

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
@@ -137,8 +137,6 @@ HdLuxCoreRenderDelegate::_Initialize()
 
     lc_session = luxcore::RenderSession::Create(lc_config);
 
-    lc_session->Start();
-
     // Store top-level objects inside a render param that can be
     // passed to prims during Sync(). Also pass a handle to the render thread.
     _renderParam = std::make_shared<HdLuxCoreRenderParam>(
@@ -278,7 +276,9 @@ HdLuxCoreRenderDelegate::CreateRprim(TfToken const& typeId,
 {
     cout << "HdLuxCoreRenderDelegate::CreateRprim(TfToken const& typeId, SdfPath const& rprimId, SdfPath const& instancerId)\n";
     if (typeId == HdPrimTypeTokens->mesh) {
-        return new HdLuxCoreMesh(rprimId, instancerId);
+        HdLuxCoreMesh *mesh = new HdLuxCoreMesh(rprimId, instancerId);
+        _rprimMap[rprimId.GetString()] = mesh;
+        return mesh;
     } else {
         TF_CODING_ERROR("Unknown Rprim Type %s", typeId.GetText());
     }

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
@@ -230,6 +230,8 @@ public:
     virtual HdAovDescriptor
         GetDefaultAovDescriptor(TfToken const& name) const override;
 
+    // A map of rprims
+    TfHashMap<std::string, HdLuxCoreMesh*> _rprimMap;
 private:
     static const TfTokenVector SUPPORTED_RPRIM_TYPES;
     static const TfTokenVector SUPPORTED_SPRIM_TYPES;


### PR DESCRIPTION
This PR makes LuxCore rendering thread-safe in the USD delegate by relocating LuxCore scene definitions to the renderPass. Multiple meshes now render without crashing the delegate.

![luxcore_full_scene_render_2020_03_28](https://user-images.githubusercontent.com/14242682/77840438-51a58580-713c-11ea-8ecb-f6c73dca8854.png)