### PR TITLE
Fix RenderPass Instancing

### DIFF
--- a/pxr/imaging/plugin/hdLuxCore/mesh.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/mesh.cpp
@@ -197,8 +197,8 @@ HdLuxCoreMesh::CreateLuxCoreTriangleMesh(HdRenderParam* renderParam)
         verticies[i*3+2] = _points[i][2];
     }
 
-    cout << "Points: " << _points << std::flush;
-    cout << "Triangulated Indicies: " << _triangulatedIndices << std::flush;
+    //cout << "Points: " << _points << std::flush;
+    //cout << "Triangulated Indicies: " << _triangulatedIndices << std::flush;
 
     lc_scene->DefineMesh(id.GetString(), _points.size(), _triangulatedIndices.size(), verticies, triangle_indicies,  NULL, NULL, NULL, NULL);
 

--- a/pxr/imaging/plugin/hdLuxCore/mesh.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/mesh.cpp
@@ -135,6 +135,8 @@ HdLuxCoreMesh::Sync(HdSceneDelegate *sceneDelegate,
     HD_TRACE_FUNCTION();
     HF_MALLOC_TAG_FUNCTION();
 
+    logit("HdLuxCoreMesh::Sync");
+
     // XXX: A mesh repr can have multiple repr decs; this is done, for example,
     // when the drawstyle specifies different rasterizing modes between front
     // faces and back faces.
@@ -151,11 +153,11 @@ HdLuxCoreMesh::Sync(HdSceneDelegate *sceneDelegate,
     HdInstancer *instancer = renderIndex.GetInstancer(GetInstancerId());
 
     if (!GetInstancerId().IsEmpty()) {
-            _transforms =
-            static_cast<HdLuxCoreInstancer*>(instancer)->
-                ComputeInstanceTransforms(GetId());
+        //_transforms = static_cast<HdLuxCoreInstancer*>(instancer)->ComputeInstanceTransforms(GetId()); 
     } else {
-        _transforms = VtMatrix4dArray();
+        GfMatrix4d *transform = new GfMatrix4d(sceneDelegate->GetTransform(GetId()));
+        //_transforms = VtMatrix4dArray();
+        _transforms.push_back(transform);
     }
 
     VtValue value = sceneDelegate->Get(GetId(), HdTokens->points);
@@ -286,6 +288,21 @@ HdLuxCoreMesh::_UpdateComputedPrimvarSources(HdSceneDelegate* sceneDelegate,
     }
 
     return compPrimvarNames;
+}
+
+bool
+HdLuxCoreMesh::IsValidTransform(GfMatrix4f m)
+{
+    float *items = m.GetArray();
+
+    for (int i = 0; i < 16; i++) {
+        if (isinf(items[i]))
+            return false;
+        if (items[i] == -0)
+            return false;
+    }
+
+    return true;
 }
 
 

--- a/pxr/imaging/plugin/hdLuxCore/mesh.h
+++ b/pxr/imaging/plugin/hdLuxCore/mesh.h
@@ -33,6 +33,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+typedef std::vector<GfMatrix4d *> TfMatrix4dVector;
 
 /// \class HdLuxCoreMesh
 ///
@@ -59,6 +60,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// embree scene), so that object population and existence aren't tied to
 /// each other.
 ///
+
 class HdLuxCoreMesh final : public HdMesh {
 public:
     HF_MALLOC_TAG_NEW("new HdLuxCoreMesh");
@@ -117,10 +119,13 @@ public:
     virtual void Finalize(HdRenderParam *renderParam) override;
 
     bool CreateLuxCoreTriangleMesh(HdRenderParam *renderParam);
-
-    virtual VtMatrix4dArray GetTransforms() const {
+    
+    virtual TfMatrix4dVector GetTransforms() const {
         return _transforms;
     }
+
+    bool HdLuxCoreMesh::IsValidTransform(GfMatrix4f m);
+    
 
 protected:
     // Initialize the given representation of this Rprim.
@@ -220,11 +225,14 @@ private:
     HdDirtyBits *_dirtyBits;
     HdMeshReprDesc _desc;
     HdSceneDelegate *_sceneDelegate;
-    VtMatrix4dArray _transforms;
+    //VtMatrix4dArray _transforms;
+    TfMatrix4dVector _transforms;
+    
+
     VtVec3fArray _points;
     VtVec3iArray _triangulatedIndices;
     HdMeshTopology _topology;
-    GfMatrix4f _transform;
+    GfMatrix4d _transform;
 
     // This class does not support copying.
     HdLuxCoreMesh(const HdLuxCoreMesh&)             = delete;

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
@@ -39,6 +39,8 @@
 //XXX: Add bprim types
 
 #include <iostream>
+#include <chrono>
+#include <ctime>
 using namespace std;
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -367,3 +369,13 @@ HdLuxCoreRenderDelegate::DestroyBprim(HdBprim *bPrim)
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE
+
+
+
+int logit(std::string message)
+{
+    auto timenow = chrono::system_clock::to_time_t(chrono::system_clock::now()); 
+    cout << "LOG: " << ctime(&timenow) << " Thread: " << std::this_thread::get_id() << message << endl;
+
+    return 0;
+}

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
@@ -34,6 +34,9 @@
 #include <luxcore/luxcore.h>
 #include <mutex>
 
+
+int logit(std::string message);
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdLuxCoreRenderParam;

--- a/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
@@ -142,7 +142,7 @@ HdLuxCoreRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
         lc_session->Stop();
         lc_scene->Parse(luxrays::Properties() <<
             luxrays::Property("scene.camera.type")("perspective") <<
-            luxrays::Property("scene.camera.lookat.orig")(origin[0], 5.0f, origin[2]) <<
+            luxrays::Property("scene.camera.lookat.orig")(origin[0], origin[1], origin[2]) <<
             luxrays::Property("scene.camera.lookat.target")(direction[0], direction[1], direction[2]) <<
             luxrays::Property("scene.camera.up")(up[0], up[1], up[2]) <<
             luxrays::Property("scene.camera.fieldofview")(fieldOfView)

--- a/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
@@ -164,25 +164,17 @@ HdLuxCoreRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
         if (!lc_scene->IsMeshDefined(mesh->GetId().GetString())) {
             if (mesh->CreateLuxCoreTriangleMesh(renderParam)) {
                 TfMatrix4dVector transforms = mesh->GetTransforms();
-                // Always instantiate at least one mesh instance for each mesh prototype
-                for (size_t i = 0; i <= transforms.size(); i++)
+                // We can assume that there will always be one transform per mesh prototype
+                for (size_t i = 0; i < transforms.size(); i++)
                 {
                     std::string instanceName = mesh->GetId().GetString() + std::to_string(i);
                     lc_scene->Parse(
                         luxrays::Property("scene.objects." + instanceName + ".shape")(mesh->GetId().GetString()) <<
                         luxrays::Property("scene.objects." + instanceName + ".material")("mat_red")
                     );
-
-                    if (transforms.size() > 0 && transforms.size() <= i) {
-                        GfMatrix4d *t = transforms[i];
-                        GfMatrix4f m = GfMatrix4f(*t);
-                        
-                        // If the transform isn't valid for LuxCore, replace it with the identity Matrix
-                        if (!mesh->IsValidTransform(m)) {
-                            m = GfMatrix4f(1.0);
-                        }
-                        lc_scene->UpdateObjectTransformation(instanceName, m.GetArray());
-                    }
+                    GfMatrix4d *t = transforms[i];
+                    GfMatrix4f m = GfMatrix4f(*t);
+                    lc_scene->UpdateObjectTransformation(instanceName, m.GetArray());
                 }
             }
         }

--- a/script/test.bat
+++ b/script/test.bat
@@ -1,2 +1,4 @@
 usdview --renderer LuxCore test\asset\geo_GridSphereLightCam.004.usd_scene.usda
 rem usdview test\asset\geo_GridSphereLightCam.004.usd_scene.usda
+rem usdview --renderer LuxCore test\asset\helloworld_instances.usda
+rem usdview test\asset\geo_GridSphereLightCam.004.usd_scene.usda

--- a/test/asset/geo_GridSphereLightCam.004.usd_scene.usda
+++ b/test/asset/geo_GridSphereLightCam.004.usd_scene.usda
@@ -9,24 +9,30 @@
     upAxis = "Y"
 )
 
+def Xform "grid1" (
+    kind = "component"
+)
+{
+    matrix4d xformOp:transform:xform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
+    uniform token[] xformOpOrder = ["xformOp:transform:xform"]
+
+    def Mesh "mesh_0"
+    {
+        float3[] extent = [(-1.5, 0, -1.5), (1.5, 0, 1.5)]
+        int[] faceVertexCounts = [4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 4, 3, 1, 2, 5, 4, 3, 4, 7, 6, 4, 5, 8, 7]
+        uniform token orientation = "leftHanded"
+        point3f[] points = [(-1.5, 0, -1.5), (0, 0, -1.5), (1.5, 0, -1.5), (-1.5, 0, 0), (0, 0, 0), (1.5, 0, 0), (-1.5, 0, 1.5), (0, 0, 1.5), (1.5, 0, 1.5)] (
+            interpolation = "vertex"
+        )
+        uniform token subdivisionScheme = "none"
+    }
+}
+
 def Sphere "sphere1"
 {
     double radius = 1
     matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 1.038795344531536, 0, 1) )
-    uniform token[] xformOpOrder = ["xformOp:transform", "xformOp:transform"]
-}
-
-def Sphere "sphere2"
-{
-    double radius = 1
-    matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 2.038795344531536, 0, 1) )
-    uniform token[] xformOpOrder = ["xformOp:transform"]
-}
-
-def Sphere "sphere3"
-{
-    double radius = 1
-    matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 3.038795344531536, 0, 1) )
     uniform token[] xformOpOrder = ["xformOp:transform"]
 }
 

--- a/test/asset/geo_GridSphereLightCam.004.usd_scene.usda
+++ b/test/asset/geo_GridSphereLightCam.004.usd_scene.usda
@@ -9,30 +9,24 @@
     upAxis = "Y"
 )
 
-def Xform "grid1" (
-    kind = "component"
-)
-{
-    matrix4d xformOp:transform:xform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
-    uniform token[] xformOpOrder = ["xformOp:transform:xform"]
-
-    def Mesh "mesh_0"
-    {
-        float3[] extent = [(-1.5, 0, -1.5), (1.5, 0, 1.5)]
-        int[] faceVertexCounts = [4, 4, 4, 4]
-        int[] faceVertexIndices = [0, 1, 4, 3, 1, 2, 5, 4, 3, 4, 7, 6, 4, 5, 8, 7]
-        uniform token orientation = "leftHanded"
-        point3f[] points = [(-1.5, 0, -1.5), (0, 0, -1.5), (1.5, 0, -1.5), (-1.5, 0, 0), (0, 0, 0), (1.5, 0, 0), (-1.5, 0, 1.5), (0, 0, 1.5), (1.5, 0, 1.5)] (
-            interpolation = "vertex"
-        )
-        uniform token subdivisionScheme = "none"
-    }
-}
-
 def Sphere "sphere1"
 {
     double radius = 1
     matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 1.038795344531536, 0, 1) )
+    uniform token[] xformOpOrder = ["xformOp:transform", "xformOp:transform"]
+}
+
+def Sphere "sphere2"
+{
+    double radius = 1
+    matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 2.038795344531536, 0, 1) )
+    uniform token[] xformOpOrder = ["xformOp:transform"]
+}
+
+def Sphere "sphere3"
+{
+    double radius = 1
+    matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 3.038795344531536, 0, 1) )
     uniform token[] xformOpOrder = ["xformOp:transform"]
 }
 


### PR DESCRIPTION
This PR fixes a bug that was causing mesh instances to trigger a crash in renderPass.  It also adds more sophisticated logging.