### PR TITLE
Add sphere lighting support

### DIFF
--- a/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
@@ -53,6 +53,7 @@ pxr_plugin(hdLuxCore
         renderer
         renderBuffer
         mesh
+        light
 
     PUBLIC_HEADERS
         renderParam.h

--- a/pxr/imaging/plugin/hdLuxCore/light.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/light.cpp
@@ -1,0 +1,24 @@
+#include "pxr/imaging/hdLuxCore/light.h"
+#include "pxr/imaging/hdLuxCore/renderDelegate.h"
+
+using namespace std;
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+void HdLuxCoreLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits) {
+    cout << "HdLuxCoreLight::Sync\n" << std::flush;
+
+    _transform = sceneDelegate->GetTransform(GetId());
+    _color = sceneDelegate->GetLightParamValue(GetId(), HdPrimvarRoleTokens->color).Get<GfVec3f>();
+    _intensity = sceneDelegate->GetLightParamValue(GetId(), HdLightTokens->intensity).Get<float>();
+}
+
+void HdLuxCoreLight::Finalize(HdRenderParam* renderParam) {
+}
+
+HdDirtyBits HdLuxCoreLight::GetInitialDirtyBitsMask() const {
+    return DirtyBits::DirtyTransform
+         | DirtyBits::DirtyParams;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdLuxCore/light.h
+++ b/pxr/imaging/plugin/hdLuxCore/light.h
@@ -1,0 +1,64 @@
+#ifndef HDLUXCORE_LIGHT_H
+#define HDLUXCORE_LIGHT_H
+
+#include "pxr/base/gf/vec3f.h"
+#include "pxr/base/gf/matrix4f.h"
+#include "pxr/imaging/hd/light.h"
+#include "pxr/usd/usdLux/tokens.h"
+#include "pxr/pxr.h"
+#include "pxr/base/gf/matrix4d.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdLuxCoreLight : public HdLight {
+    public:
+        HdLuxCoreLight(SdfPath const& id, TfToken const& lightType)
+            : HdLight(id), _lightType(lightType) {
+                _created = false;
+            }
+
+        ~HdLuxCoreLight() override = default;
+
+        void Sync(HdSceneDelegate* sceneDelegate,
+              HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits) override;
+
+        HdDirtyBits GetInitialDirtyBitsMask() const override;
+
+        void Finalize(HdRenderParam* renderParam) override;
+
+        virtual GfMatrix4d GetLightTransform() const {
+            return _transform;
+        }
+        
+        virtual float GetIntensity() const {
+            return _intensity;
+        }
+        
+        virtual GfVec3f GetColor() const {
+            return _color;
+        }
+
+        virtual const TfToken GetLightType() const {
+            return _lightType;
+        }
+
+        virtual bool GetCreated() const {
+            return _created;
+        }
+
+        virtual void SetCreated(bool created) {
+            _created = created;
+        }
+
+    private:
+        GfMatrix4d _transform;
+        float _intensity = 1.0;
+        GfVec3f _color = GfVec3f(0.0f);
+        const TfToken _lightType;
+        bool _created;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDLUXCORE_LIGHT_H

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
@@ -32,6 +32,7 @@
 #include "pxr/imaging/hd/resourceRegistry.h"
 #include "pxr/imaging/hd/tokens.h"
 
+
 //XXX: Add other Rprim types later
 #include "pxr/imaging/hd/camera.h"
 //XXX: Add other Sprim types later
@@ -56,6 +57,7 @@ const TfTokenVector HdLuxCoreRenderDelegate::SUPPORTED_SPRIM_TYPES =
 {
     HdPrimTypeTokens->camera,
     HdPrimTypeTokens->extComputation,
+    HdPrimTypeTokens->sphereLight
 };
 
 const TfTokenVector HdLuxCoreRenderDelegate::SUPPORTED_BPRIM_TYPES =
@@ -115,10 +117,11 @@ HdLuxCoreRenderDelegate::_Initialize()
     //Luxcore requires at least one light source, so we are hardcoding one in until we
     //can parse them from USD directives
     lc_scene->Parse(
-        luxrays::Property("scene.lights.defaultsky.type")("sky2") <<
-        luxrays::Property("scene.lights.defaultsky.dir")(0.166974f, 0.59908f, 0.783085f) <<
-        luxrays::Property("scene.lights.defaultsky.turbidity")(2.2f) <<
-        luxrays::Property("scene.lights.defaultsky.gain")(0.8f, 0.8f, 0.8f)
+        luxrays::Property("scene.lights.light1.type")("sphere") <<
+        luxrays::Property("scene.lights.light1.color")(1.0, 0.0, 0.0) <<
+        luxrays::Property("scene.lights.light1.gain")(2.0, 2.0, 2.0) <<
+        luxrays::Property("scene.lights.light1.direction")(1.0, 1.0, -1.0) <<
+        luxrays::Property("scene.lights.light1.position")(1.55, 1.95, 0.66)
     );
 
     // TODO: define actual materials elsewhere
@@ -304,6 +307,8 @@ HdLuxCoreRenderDelegate::CreateSprim(TfToken const& typeId,
         return new HdCamera(sprimId);
     } else if (typeId == HdPrimTypeTokens->extComputation) {
         return new HdExtComputation(sprimId);
+    } else if (typeId == HdPrimTypeTokens->sphereLight) {
+        return new HdLuxCoreLight(sprimId, typeId);
     } else {
         TF_CODING_ERROR("Unknown Sprim Type %s", typeId.GetText());
     }
@@ -321,6 +326,8 @@ HdLuxCoreRenderDelegate::CreateFallbackSprim(TfToken const& typeId)
         return new HdCamera(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->extComputation) {
         return new HdExtComputation(SdfPath::EmptyPath());
+    } else if (typeId == HdPrimTypeTokens->sphereLight) {
+        return new HdLuxCoreLight(SdfPath::EmptyPath(), typeId);
     } else {
         TF_CODING_ERROR("Unknown Sprim Type %s", typeId.GetText());
     }

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.cpp
@@ -118,8 +118,8 @@ HdLuxCoreRenderDelegate::_Initialize()
     //can parse them from USD directives
     lc_scene->Parse(
         luxrays::Property("scene.lights.light1.type")("sphere") <<
-        luxrays::Property("scene.lights.light1.color")(1.0, 0.0, 0.0) <<
-        luxrays::Property("scene.lights.light1.gain")(2.0, 2.0, 2.0) <<
+        luxrays::Property("scene.lights.light1.color")(0.0, 1.0, 0.0) <<
+        luxrays::Property("scene.lights.light1.gain")(0.0, 0.0, 0.0) <<
         luxrays::Property("scene.lights.light1.direction")(1.0, 1.0, -1.0) <<
         luxrays::Property("scene.lights.light1.position")(1.55, 1.95, 0.66)
     );
@@ -302,13 +302,15 @@ HdSprim *
 HdLuxCoreRenderDelegate::CreateSprim(TfToken const& typeId,
                                     SdfPath const& sprimId)
 {
-    cout << "HdLuxCoreRenderDelegate::CreateSprim(TfToken const& typeId, SdfPath const& sprimId)\n";
+    cout << "HdLuxCoreRenderDelegate::CreateSprim(TfToken const& typeId, SdfPath const& sprimId) " << sprimId << "\n";
     if (typeId == HdPrimTypeTokens->camera) {
         return new HdCamera(sprimId);
     } else if (typeId == HdPrimTypeTokens->extComputation) {
         return new HdExtComputation(sprimId);
     } else if (typeId == HdPrimTypeTokens->sphereLight) {
-        return new HdLuxCoreLight(sprimId, typeId);
+        HdLuxCoreLight *light = new HdLuxCoreLight(sprimId, typeId);
+        _sprimLightMap[sprimId.GetString()] = light;
+        return light;
     } else {
         TF_CODING_ERROR("Unknown Sprim Type %s", typeId.GetText());
     }

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
@@ -236,6 +236,8 @@ public:
 
     // A map of rprims
     TfHashMap<std::string, HdLuxCoreMesh*> _rprimMap;
+    // A map of sprim Lights
+    TfHashMap<std::string, HdLuxCoreLight*> _sprimLightMap;
 private:
     static const TfTokenVector SUPPORTED_RPRIM_TYPES;
     static const TfTokenVector SUPPORTED_SPRIM_TYPES;

--- a/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderDelegate.h
@@ -30,6 +30,7 @@
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/imaging/hdLuxCore/renderer.h"
 #include "pxr/imaging/hdLuxCore/mesh.h"
+#include "pxr/imaging/hdLuxCore/light.h"
 
 #include <luxcore/luxcore.h>
 #include <mutex>


### PR DESCRIPTION
This PR adds sprim support for sphere lights.  This adds a hashmap container in the render delegate to store lighting sprims for later rendering during the RenderPass.