### PR TITLE
Add camera primitive

### DIFF
--- a/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdLuxCore/CMakeLists.txt
@@ -52,6 +52,7 @@ pxr_plugin(hdLuxCore
         renderPass
         mesh
         light
+        camera
 
     PUBLIC_HEADERS
         renderParam.h

--- a/pxr/imaging/plugin/hdLuxCore/camera.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/camera.cpp
@@ -1,0 +1,47 @@
+//
+// Copyright 2017 Pixar and John Gann
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "pxr/imaging/hdLuxCore/camera.h"
+
+using namespace std;
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdLuxCoreCamera::HdLuxCoreCamera(SdfPath const& id)
+	: HdCamera(id)
+{
+}
+
+void HdLuxCoreCamera::Sync(HdSceneDelegate* sceneDelegate,
+	HdRenderParam* renderParam,
+	HdDirtyBits* dirtyBits) {
+
+	if (*dirtyBits & HdCamera::DirtyViewMatrix) {
+		sceneDelegate->SampleTransform(GetId(), &_transform);
+	}
+
+	HdCamera::Sync(sceneDelegate, renderParam, dirtyBits);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdLuxCore/camera.h
+++ b/pxr/imaging/plugin/hdLuxCore/camera.h
@@ -1,0 +1,52 @@
+//
+// Copyright 2017 Pixar and John Gann
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#ifndef HDLUXCORE_CAMERA_H
+#define HDLUXCORE_CAMERA_H
+
+#include "pxr/imaging/hd/camera.h"
+#include "pxr/imaging/hd/sceneDelegate.h"
+
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdLuxCoreCamera : public HdCamera {
+
+public:
+
+	HdLuxCoreCamera(SdfPath const& id);
+	~HdLuxCoreCamera() override = default;
+
+	void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits);
+
+private:
+	HdTimeSampleArray<GfMatrix4d, 2> _transform;
+};
+
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+
+#endif
+


### PR DESCRIPTION
This PR adds a custom HdLuxCore camera primitive object.