### PR TITLE
Cleanup comments, whitespace, and default material

### DIFF
--- a/pxr/imaging/plugin/hdLuxCore/mesh.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/mesh.cpp
@@ -225,7 +225,6 @@ HdLuxCoreMesh::CreateLuxCoreTriangleMesh(HdRenderParam* renderParam)
 {
     cout << "_CreateLuxCoreTriangleMesh " << std::flush;
     Scene *lc_scene = reinterpret_cast<HdLuxCoreRenderParam*>(renderParam)->_scene;
-    RenderSession *lc_session = reinterpret_cast<HdLuxCoreRenderParam*>(renderParam)->_session;
 
     // Used to name the type of mesh in LuxCore
     SdfPath const& id = GetId();
@@ -406,17 +405,12 @@ HdLuxCoreMesh::CreateLuxCoreTriangleMesh(HdRenderParam* renderParam)
     unsigned int *triangle_indicies = (unsigned int *)Scene::AllocTrianglesBuffer(_triangulatedIndices.size());
     triangle_indicies = (unsigned int *)_triangulatedIndices.cdata();
 
-    // todo: rescale camera so we don't have to x 100 these
-    // also cast these as above
     float *verticies = (float *)Scene::AllocVerticesBuffer(_points.size());
-    for (int i = 0; i < _points.size(); i++) {
+    for (unsigned int i = 0; i < _points.size(); i++) {
         verticies[i*3+0] = _points[i][0];
         verticies[i*3+1] = _points[i][1];
         verticies[i*3+2] = _points[i][2];
     }
-
-    //cout << "Points: " << _points << std::flush;
-    //cout << "Triangulated Indicies: " << _triangulatedIndices << std::flush;
 
     lc_scene->DefineMesh(id.GetString(), _points.size(), _triangulatedIndices.size(), verticies, triangle_indicies,  NULL, NULL, NULL, NULL);
 

--- a/pxr/imaging/plugin/hdLuxCore/mesh.h
+++ b/pxr/imaging/plugin/hdLuxCore/mesh.h
@@ -90,14 +90,8 @@ public:
 /// updated LuxCore geometry objects.  Rebuilding the acceleration datastructures
 /// is deferred to HdLuxCoreRenderDelegate::CommitResources(), which runs after
 /// all prims have been updated. After running Sync() for each prim and
-/// HdEmbreeRenderDelegate::CommitResources(), the scene should be ready for
+/// HdLuxCoreRenderDelegate::CommitResources(), the scene should be ready for
 /// rendering via ray queries.
-///
-/// An rprim's state is lazily populated in Sync(); matching this, Finalize()
-/// does the heavy work of releasing state (such as handles into the top-level
-/// embree scene), so that object population and existence aren't tied to
-/// each other.
-///
 
 class HdLuxCoreMesh final : public HdMesh {
 public:
@@ -115,8 +109,7 @@ public:
     virtual ~HdLuxCoreMesh() = default;
 
     /// Inform the scene graph which state needs to be downloaded in the
-    /// first Sync() call: in this case, topology and points data to build
-    /// the geometry object in the embree scene graph.
+    /// first Sync() call
     ///   \return The initial dirty state this mesh wants to query.
     virtual HdDirtyBits GetInitialDirtyBitsMask() const override;
 
@@ -140,8 +133,7 @@ public:
     /// Reprs are used by hydra for controlling per-item draw settings like
     /// flat/smooth shaded, wireframe, refined, etc.
     ///   \param sceneDelegate The data source for this geometry item.
-    ///   \param renderParam An HdEmbreeRenderParam object containing top-level
-    ///                      embree state.
+    ///   \param renderParam An HdLuxCoreRenderParam object
     ///   \param dirtyBits A specifier for which scene data has changed.
     ///   \param reprToken A specifier for which representation to draw with.
     ///
@@ -150,10 +142,8 @@ public:
                       HdDirtyBits*     dirtyBits,
                       TfToken const    &reprToken) override;
 
-    /// Release any resources this class is holding onto: in this case,
-    /// destroy the geometry object in the embree scene graph.
-    ///   \param renderParam An HdEmbreeRenderParam object containing top-level
-    ///                      embree state.
+    /// Release any resources this class is holding onto
+    ///   \param renderParam An HdLuxCoreRenderParam object
     virtual void Finalize(HdRenderParam *renderParam) override;
 
     bool CreateLuxCoreTriangleMesh(HdRenderParam *renderParam);

--- a/pxr/imaging/plugin/hdLuxCore/renderParam.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderParam.h
@@ -21,8 +21,8 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#ifndef HDEMBREE_RENDER_PARAM_H
-#define HDEMBREE_RENDER_PARAM_H
+#ifndef HDLUXCORE_RENDER_PARAM_H
+#define HDLUXCORE_RENDER_PARAM_H
 
 #include "pxr/pxr.h"
 #include "pxr/imaging/hd/renderDelegate.h"
@@ -74,4 +74,4 @@ public:
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
-#endif // HDEMBREE_RENDER_PARAM_H
+#endif // HDLUXCORE_RENDER_PARAM_H

--- a/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
@@ -147,7 +147,7 @@ HdLuxCoreRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
                     std::string instanceName = mesh->GetId().GetString() + std::to_string(i);
                     lc_scene->Parse(
                         luxrays::Property("scene.objects." + instanceName + ".shape")(mesh->GetId().GetString()) <<
-                        luxrays::Property("scene.objects." + instanceName + ".material")("mat_red")
+                        luxrays::Property("scene.objects." + instanceName + ".material")("mat_default")
                     );
                     GfMatrix4d *t = transforms[i];
                     GfMatrix4f m = GfMatrix4f(*t);

--- a/pxr/imaging/plugin/hdLuxCore/renderPass.h
+++ b/pxr/imaging/plugin/hdLuxCore/renderPass.h
@@ -21,8 +21,8 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#ifndef HDEMBREE_RENDER_PASS_H
-#define HDEMBREE_RENDER_PASS_H
+#ifndef HDLUXCORE_RENDER_PASS_H
+#define HDLUXCORE_RENDER_PASS_H
 
 #include "pxr/pxr.h"
 
@@ -43,8 +43,6 @@ typedef boost::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 /// HdRenderPass represents a single render iteration, rendering a view of the
 /// scene (the HdRprimCollection) for a specific viewer (the camera/viewport
 /// parameters in HdRenderPassState) to the current draw target.
-///
-/// This class does so by raycasting into the embree scene via HdLuxCoreRenderer.
 ///
 class HdLuxCoreRenderPass final : public HdRenderPass {
 public:
@@ -118,4 +116,4 @@ private:
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
-#endif // HDEMBREE_RENDER_PASS_H
+#endif // HDLUXCORE_RENDER_PASS_H


### PR DESCRIPTION
This PR does the following:

* Removes unused variables identified by the compiler
* Removes unused default materials and renames the default material to indicate it is a default
* Adds better contextual comments to the render delegate
* Removes or redefines boilerplate comments and defines
* Cleans up whitespace