### PR TITLE
Add feature to allow toggling mesh visibility on and off

### DIFF
--- a/pxr/imaging/plugin/hdLuxCore/mesh.h
+++ b/pxr/imaging/plugin/hdLuxCore/mesh.h
@@ -152,6 +152,18 @@ public:
         return _transforms;
     }
 
+	virtual bool IsVisible() const {
+		return _visible;
+	}
+
+	virtual int GetInstancesRendered() const {
+		return _instances_rendered;
+	}
+
+	virtual void SetInstancesRendered(int count) {
+		_instances_rendered = count;
+	}
+
     bool IsValidTransform(GfMatrix4f m);
     
 
@@ -261,6 +273,9 @@ private:
 	VtVec3fArray _normals;
 	VtVec3fArray _uvs;
 	int _refineLevel;
+	bool _visible = true;
+
+	int _instances_rendered = 0;
 
     // This class does not support copying.
     HdLuxCoreMesh(const HdLuxCoreMesh&)             = delete;


### PR DESCRIPTION
This PR allows mesh visibility to be toggled on and off.  This can be readily demonstrated in the usdview utility by selecting a mesh and selecting the option to make it invisible or visible once again.

When mesh invisibility is toggled each mesh's LuxCore object is deleted.  When visibility is toggled back on, the mesh instance objects are re-created.  This PR also includes a workaround with LuxCore to prevent additive mesh transform ghosting by adding the inverse of a LuxCore mesh object's current transformation prior to removing it.