### PR TITLE
Add differentiation between point and sphere lights

### DIFF
--- a/pxr/imaging/plugin/hdLuxCore/light.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/light.cpp
@@ -23,6 +23,7 @@ void HdLuxCoreLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
         _color = sceneDelegate->GetLightParamValue(GetId(), HdPrimvarRoleTokens->color).Get<GfVec3f>();
         _intensity = sceneDelegate->GetLightParamValue(GetId(), HdLightTokens->intensity).Get<float>();
         _exposure = sceneDelegate->GetLightParamValue(GetId(), HdLightTokens->exposure).Get<float>();
+        _treatAsPoint = sceneDelegate->GetLightParamValue(GetId(), UsdLuxTokens->treatAsPoint).GetWithDefault(false);
     }
 }
 

--- a/pxr/imaging/plugin/hdLuxCore/light.h
+++ b/pxr/imaging/plugin/hdLuxCore/light.h
@@ -55,6 +55,10 @@ class HdLuxCoreLight : public HdLight {
             _created = created;
         }
 
+	virtual bool GetTreatAsPoint() const {
+            return _treatAsPoint;
+        }
+
     private:
         GfMatrix4d _transform;
         float _intensity = 1.0;
@@ -62,6 +66,7 @@ class HdLuxCoreLight : public HdLight {
         GfVec3f _color = GfVec3f(1.0f);
         const TfToken _lightType;
         bool _created;
+        bool _treatAsPoint;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
@@ -180,6 +180,7 @@ HdLuxCoreRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
     // Render any lighting
     TfHashMap<std::string, HdLuxCoreLight*> lightMap = renderDelegateLux->_sprimLightMap;
     TfHashMap<std::string, HdLuxCoreLight*>::iterator l_iter;
+    std::string light_type;
 
     // If we already have lighting, remove the default light
     if (lightMap.size() > 0) {
@@ -193,8 +194,12 @@ HdLuxCoreRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
             GfMatrix4d transform = light->GetLightTransform();
             std::string light_id = light->GetId().GetString();
             GfVec3f color = light->GetColor();
+            if (light->GetTreatAsPoint())
+                light_type = "point";
+            else
+                light_type = "sphere";
             lc_scene->Parse(
-                luxrays::Property("scene.lights." + light_id + ".type")("point") <<
+                luxrays::Property("scene.lights." + light_id + ".type")(light_type) <<
                 luxrays::Property("scene.lights." + light_id + ".color")(color[0], color[1], color[2]) <<
                 luxrays::Property("scene.lights." + light_id + ".position")(transform[3][0], transform[3][1], transform[3][2])
             );


### PR DESCRIPTION
This PR adds the functionality to differentiate between sphere lights that are marked by USD to be treated as points versus those that do not.