### PR TITLE
Fix camera transformation by preventing floating point truncation

### DIFF
--- a/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
+++ b/pxr/imaging/plugin/hdLuxCore/renderPass.cpp
@@ -101,11 +101,11 @@ HdLuxCoreRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
 
         // The calculations in the following two code blocks are borrowed from the excellent hdospray project
         // Source: https://github.com/ospray/hdospray
-        GfVec3f origin = GfVec3f(0, 0, 0);
-        GfVec3f direction = GfVec3f(0, 0, -1);
-        GfVec3f up = GfVec3f(0, 1, 0);
+        GfVec3d origin = GfVec3d(0, 0, 0);
+        GfVec3d direction = GfVec3d(0, 0, -1);
+        GfVec3d up = GfVec3d(0, 1, 0);
         double projectionMatrix[4][4];
-        float fieldOfView;
+        double fieldOfView;
 
         renderPassState->GetProjectionMatrix().Get(projectionMatrix);
         fieldOfView = (atan(1.0 / projectionMatrix[1][1]) * 180.0 * 2.0) / M_PI;


### PR DESCRIPTION
This PR fixes a camera transformation issue discovered in testing.  Previously the camera angle in rendered images would be close but not quite match the the angles of the provided test image. The issue was caused by floating point truncation happening with the camera calculations and is resolved by changing the variables used from floats to doubles.

Image comparison with the sample render image was used to detect the drift. The combined image used to detect this issue is below:
![drift_compare](https://user-images.githubusercontent.com/14242682/92984406-bc364d80-f45e-11ea-86e3-6691eb3d2fbc.png)